### PR TITLE
📖 Scribe: Fix WireGuard handshake documentation

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,0 +1,4 @@
+## 2024-03-22 - WireGuard Handshake Documentation Gap
+**Gap:** The documentation (`docs/concepts/wire-protocol.md` and `README.md`) described a custom `0x10`/`0x11` handshake protocol, while the implementation (`src/wireguard/noise.zig`) uses the standard WireGuard Noise_IKpsk2 handshake (Types 1/2).
+**Learning:** Documentation drifted because the initial design likely included a custom handshake which was replaced by standard WireGuard during implementation, but docs were not updated.
+**Prevention:** Regularly audit `messages.zig` against `device.zig` packet classification logic to ensure all documented message types are actually handled.

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Trust is **bidirectional** — both peers must have each other's key in `authori
 
 - Binary codec: type-tag-delimited, fixed-size fields, little-endian
 - SWIM: Ping (`0x01`), Ack (`0x03`), PingReq (`0x02`)
-- Handshake: Init (`0x10`), Resp (`0x11`) — signed Ed25519 + WG key exchange
-- NAT: HolepunchRequest (`0x33`), HolepunchResponse (`0x34`), EndpointUpdate (`0x32`)
+- Handshake: Standard WireGuard Noise_IKpsk2 (Type 1, Type 2)
+- NAT: HolepunchRequest (`0x33`), HolepunchResponse (`0x34`)
 
 ## Benchmarking
 


### PR DESCRIPTION
The documentation for the wire protocol was outdated and described a custom handshake mechanism (0x10/0x11) that is not used in the codebase. The actual implementation uses standard WireGuard Noise_IKpsk2 handshake messages (Types 1-4) which are multiplexed on the same UDP port as SWIM gossip messages.

This PR corrects `docs/concepts/wire-protocol.md` and `README.md` to reflect the actual implementation:
- Explains the packet classification logic (first 4 bytes).
- Replaces the incorrect handshake message definitions with the standard WireGuard handshake structures (`HandshakeInitiation` and `HandshakeResponse`).
- Removes unimplemented message types (`RelayRequest`, `RelayData`, `EndpointUpdate`) from the documentation to avoid confusion.


---
*PR created automatically by Jules for task [15455729219446802175](https://jules.google.com/task/15455729219446802175) started by @igorls*