### PR TITLE
⚡ Bolt: Optimize packet forwarding with O(1) IP lookup

### DIFF
--- a/src/wg_interop.zig
+++ b/src/wg_interop.zig
@@ -130,7 +130,7 @@ pub fn main() !void {
     try writeFormatted(stdout, "  UDP listening on :{d}\n", .{listen_port});
 
     // Add peer
-    const slot = wg_dev.addPeer(.{0} ** 32, peer_pub, ep.addr, ep.port) catch |err| {
+    const slot = wg_dev.addPeer(.{0} ** 32, peer_pub, .{0} ** 4, ep.addr, ep.port) catch |err| {
         try writeFormatted(stderr, "error: addPeer: {s}\n", .{@errorName(err)});
         std.process.exit(1);
     };


### PR DESCRIPTION
**What:**
Optimized the hot path for outgoing packet routing by eliminating the linear scan of the SWIM membership table (up to 5000 entries) for every IP packet.

**Why:**
Packet forwarding is the #1 critical path. Previously, `findPeerByMeshIp` iterated over the entire SWIM membership table to find a peer with a matching Mesh IP, then performed another lookup to find the WireGuard session. This was O(N_SWIM).

**How:**
- Added `allowed_ip` field to `WgPeer` struct (cached from SWIM peer).
- Implemented `WgDevice.findByAllowedIp` which iterates only over the `WgDevice.peers` array (fixed size 64).
- Replaced the expensive double-lookup in `src/main.zig` with this efficient lookup.

**Impact:**
- Reduces peer lookup complexity from O(N) (N=5000) to O(M) (M=64).
- Improves cache locality by accessing contiguous `WgPeer` structs.
- Eliminates dependency on SWIM data structures in the packet forwarding path.

**Verification:**
- `zig build` succeeds.
- `zig test src/wireguard/device.zig` passes relevant tests.
- `zig build test` passes (1 test suite).


---
*PR created automatically by Jules for task [10439097791647316204](https://jules.google.com/task/10439097791647316204) started by @igorls*