### PR TITLE
🛡️ Sentinel: [CRITICAL] Key material not zeroed after use

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,10 @@
 **Learning:** Developers often reach for `std.mem.eql` for all comparisons without considering the security implications for cryptographic values. The lack of a linter to catch this makes it easy to overlook.
 
 **Prevention:** Always use `std.crypto.utils.timingSafeEql` for comparing MACs, signatures, hashes, and keys. Establish a code review checklist that specifically flags `std.mem.eql` usage on byte arrays that might be secrets or cryptographic proofs.
+
+## 2026-02-24 - [CRITICAL] Sensitive Key Material Not Zeroed After Use
+**Vulnerability:** The `Handshake` struct in `src/wireguard/noise.zig` retains copies of the long-term identity key (`static_private`) and sensitive ephemeral keys (`ephemeral_private`, `precomputed_ss`, `chaining_key`) in memory. These were not explicitly zeroed out when a peer was removed or the handshake object was destroyed, potentially exposing them to memory dumps or swap files.
+
+**Learning:** Zig structs do not have automatic destructors (RAII) like C++ or Rust. Developers must manually implement `deinit` methods and ensure they are called. `WgDevice.removePeer` simply set the peer slot to `null`, which leaves the old memory content intact in the fixed-size array until overwritten by a new peer.
+
+**Prevention:** Implement `deinit` methods for all structs holding sensitive data that use `std.crypto.secureZero`. Audit all lifecycle management points (like `removePeer`) to ensure explicit cleanup is performed before releasing references.


### PR DESCRIPTION
This PR addresses a critical security vulnerability where sensitive key material (static private keys, shared secrets, chaining keys) was left in memory after a handshake session or when a peer was removed.

Changes:
- Added `deinit` method to `src/wireguard/noise.zig:Handshake` which uses `std.crypto.secureZero` to wipe all sensitive fields.
- Updated `deriveTransportKeys` in `src/wireguard/noise.zig` to securely zero ephemeral secrets (`chaining_key`, `hash`, `remote_ephemeral`) immediately after deriving transport keys.
- Modified `src/wireguard/device.zig:removePeer` to call `peer.handshake.deinit()` before removing the peer from the `peers` array, ensuring the memory is scrubbed.
- Added a test case in `src/wireguard/noise.zig` to verify `deinit` functionality.
- Updated `.jules/sentinel.md` with the vulnerability finding and fix.

This ensures that even if memory is dumped or swapped, long-lived secrets are minimized in memory and ephemeral secrets are discarded promptly.

---
*PR created automatically by Jules for task [5565583968971290168](https://jules.google.com/task/5565583968971290168) started by @igorls*