### PR TITLE
docs: fix CLI flags and default ports

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -2,3 +2,8 @@
 **Gap:** The documentation (`docs/concepts/wire-protocol.md` and `README.md`) described a custom `0x10`/`0x11` handshake protocol, while the implementation (`src/wireguard/noise.zig`) uses the standard WireGuard Noise_IKpsk2 handshake (Types 1/2).
 **Learning:** Documentation drifted because the initial design likely included a custom handshake which was replaced by standard WireGuard during implementation, but docs were not updated.
 **Prevention:** Regularly audit `messages.zig` against `device.zig` packet classification logic to ensure all documented message types are actually handled.
+
+## 2026-02-24 - CLI Flags and Default Ports Drift
+**Gap:** CLI flags `--port` and `--wg-port` were documented but not implemented in `src/main.zig`. Default WireGuard port was documented as `51820` but hardcoded as `51830`.
+**Learning:** `src/main.zig` uses hardcoded values and manual argument parsing instead of the `src/config.zig` struct or a centralized CLI parser, leading to drift between the config module, the main entry point, and the docs.
+**Prevention:** Refactor `src/main.zig` to use a CLI library that auto-generates help text from the `Config` struct, or add a CI check that grep's `main.zig` for every flag listed in `docs/reference/cli.md`.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -29,8 +29,8 @@ $MESHGUARD_CONFIG_DIR/
 | Flag         | Default  | Description                                      |
 | ------------ | -------- | ------------------------------------------------ |
 | `--seed`     | _(none)_ | Seed peer address (`ip:port`). Can be repeated.  |
-| `--port`     | `51821`  | UDP port for gossip + discovery                  |
-| `--wg-port`  | `51820`  | WireGuard listen port                            |
+| `--dns`      | _(none)_ | Discover seeds via DNS TXT records               |
+| `--mdns`     | `false`  | Discover seeds via mDNS on LAN                   |
 | `--announce` | _(auto)_ | Manually announce this IP to peers               |
 | `--kernel`   | `false`  | Use kernel WireGuard module instead of userspace |
 
@@ -51,7 +51,7 @@ $MESHGUARD_CONFIG_DIR/
 | Parameter         | Value          | Source             |
 | ----------------- | -------------- | ------------------ |
 | Gossip port       | `51821`        | `config.zig`       |
-| WireGuard port    | `51820`        | `config.zig`       |
+| WireGuard port    | `51830`        | `config.zig`       |
 | Mesh prefix       | `10.99.0.0/16` | `wireguard/ip.zig` |
 | Interface name    | `mg0`          | `wg_config.zig`    |
 | MTU               | `1420`         | `tun.zig`          |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -76,8 +76,8 @@ meshguard up [options]
 | Flag         | Default  | Description                                 |
 | ------------ | -------- | ------------------------------------------- |
 | `--seed`     | _(none)_ | Seed peer `ip:port`. Can be repeated.       |
-| `--port`     | `51821`  | UDP gossip port                             |
-| `--wg-port`  | `51820`  | WireGuard listen port                       |
+| `--dns`      | _(none)_ | Discover seeds via DNS TXT records          |
+| `--mdns`     | `false`  | Discover seeds via mDNS on LAN              |
 | `--announce` | _(auto)_ | Manually specify public IP for announcement |
 | `--kernel`   | `false`  | Use kernel WireGuard instead of userspace   |
 


### PR DESCRIPTION
Found a documentation gap where `docs/guide/configuration.md` and `docs/reference/cli.md` listed CLI flags (`--port`, `--wg-port`) that were not implemented in the source code (`src/main.zig`), and listed an incorrect default WireGuard port (`51820` vs actual `51830`).

Changes:
- Removed `--port` and `--wg-port` from CLI reference tables.
- Added `--dns` and `--mdns` flags which were present in code but missing from docs.
- Corrected default WireGuard port to `51830`.
- Updated `.jules/scribe.md` with learnings about documentation drift caused by manual CLI parsing.

---
*PR created automatically by Jules for task [11528592012730649484](https://jules.google.com/task/11528592012730649484) started by @igorls*