### PR TITLE
📖 Scribe: Document missing org and upgrade CLI commands

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -12,3 +12,7 @@
 **Gap:** The documentation stated the SWIM protocol period was 1000ms (1s), but the implementation uses 5000ms (5s) in both `src/config.zig` and `src/discovery/swim.zig`.
 **Learning:** The documentation likely reflected an early design decision or standard SWIM defaults, but the implementation settled on a more conservative 5s interval for WAN stability, and docs were not updated.
 **Prevention:** Add a CI check that grep's `docs/guide/configuration.md` for values that match constants exported in `src/config.zig`.
+## 2026-03-10 - Manual CLI Drift
+**Gap:** The org-keygen, org-sign, org-vouch, and upgrade commands were completely missing from docs/reference/cli.md despite existing in src/main.zig.
+**Learning:** Because CLI argument parsing and help messages in src/main.zig are implemented manually rather than using a generator framework, the CLI reference documentation (docs/reference/cli.md) is highly prone to drift if not updated concurrently.
+**Prevention:** We need to habitually check the fn main() switch cases or the usage string block in src/main.zig whenever updating CLI docs to ensure no commands have been added without corresponding documentation updates.

--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -12,7 +12,8 @@
 **Gap:** The documentation stated the SWIM protocol period was 1000ms (1s), but the implementation uses 5000ms (5s) in both `src/config.zig` and `src/discovery/swim.zig`.
 **Learning:** The documentation likely reflected an early design decision or standard SWIM defaults, but the implementation settled on a more conservative 5s interval for WAN stability, and docs were not updated.
 **Prevention:** Add a CI check that grep's `docs/guide/configuration.md` for values that match constants exported in `src/config.zig`.
+
 ## 2026-03-10 - Manual CLI Drift
 **Gap:** The org-keygen, org-sign, org-vouch, and upgrade commands were completely missing from docs/reference/cli.md despite existing in src/main.zig.
 **Learning:** Because CLI argument parsing and help messages in src/main.zig are implemented manually rather than using a generator framework, the CLI reference documentation (docs/reference/cli.md) is highly prone to drift if not updated concurrently.
-**Prevention:** We need to habitually check the fn main() switch cases or the usage string block in src/main.zig whenever updating CLI docs to ensure no commands have been added without corresponding documentation updates.
+**Prevention:** We need to habitually check the `if (std.mem.eql(...))` command-dispatch chain and the usage/help string block in src/main.zig whenever updating CLI docs to ensure no commands have been added without corresponding documentation updates.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -243,3 +243,58 @@ meshguard connect --join mg://...
 | Variable               | Description                                                |
 | ---------------------- | ---------------------------------------------------------- |
 | `MESHGUARD_CONFIG_DIR` | Override config directory (default: `~/.config/meshguard`) |
+
+---
+
+## `meshguard org-keygen`
+
+Generate a new Ed25519 organization keypair.
+
+```bash
+meshguard org-keygen
+```
+
+**Output files** (in `$MESHGUARD_CONFIG_DIR`):
+
+- `org.key` — secret key (permissions `0600`)
+- `org.pub` — public key
+
+---
+
+## `meshguard org-sign`
+
+Sign a node's public key with the organization key.
+
+```bash
+meshguard org-sign <node-key-or-path> [--name <label>] [--expires <unix-timestamp>]
+```
+
+| Argument | Description |
+| -------- | ----------- |
+| `<node-key-or-path>` | Base64 public key string _or_ path to a `.pub` file |
+| `--name` | Human-readable name for the node |
+| `--expires` | Unix timestamp when the signature expires (default: 0, never expires) |
+
+---
+
+## `meshguard org-vouch`
+
+Vouch for an external node. This action auto-propagates to organization members.
+
+```bash
+meshguard org-vouch <node-key-or-path>
+```
+
+| Argument | Description |
+| -------- | ----------- |
+| `<node-key-or-path>` | Base64 public key string _or_ path to a `.pub` file |
+
+---
+
+## `meshguard upgrade`
+
+Upgrade meshguard to the latest release from GitHub.
+
+```bash
+meshguard upgrade
+```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -254,10 +254,10 @@ Generate a new Ed25519 organization keypair.
 meshguard org-keygen
 ```
 
-**Output files** (in `$MESHGUARD_CONFIG_DIR`):
+**Output files** (in `$MESHGUARD_CONFIG_DIR/org/`):
 
-- `org.key` — secret key (permissions `0600`)
-- `org.pub` — public key
+- `org/org.key` — secret key (permissions `0600`)
+- `org/org.pub` — public key
 
 ---
 
@@ -295,6 +295,21 @@ meshguard org-vouch <node-key-or-path>
 
 Upgrade meshguard to the latest release from GitHub.
 
+> **Platform:** Linux (amd64) only. This command downloads the `meshguard-linux-amd64` asset from the latest GitHub release. It is not supported on other operating systems or architectures.
+>
+> **Privileges:** Requires write access to `/usr/local/bin/meshguard`. Run with `sudo` if the current user does not have sufficient permissions.
+>
+> **Service management:** Uses `systemctl` to stop the `meshguard` service before installing the new binary and restart it afterwards. Ensure `systemd` is available on your system.
+
 ```bash
 meshguard upgrade
+# or, if elevated privileges are required:
+sudo meshguard upgrade
 ```
+
+The command:
+1. Queries the GitHub Releases API for the latest tag.
+2. Downloads `meshguard-linux-amd64` from that release.
+3. Stops the `meshguard` systemd service.
+4. Installs the new binary to `/usr/local/bin/meshguard`.
+5. Restarts the `meshguard` systemd service.


### PR DESCRIPTION
### 💡 What
Four CLI commands were completely missing from the CLI reference documentation: `org-keygen`, `org-sign`, `org-vouch`, and `upgrade`.

### 🔍 Source
The ground truth implementation for these commands is located in `src/main.zig` within the `main` function's argument parsing logic and the `usage` string constant.

### 📝 Fix
Appended the documentation for the following commands to `docs/reference/cli.md`, complete with descriptions, argument definitions, and examples that match the behavior in `src/main.zig`:
- `meshguard org-keygen`
- `meshguard org-sign`
- `meshguard org-vouch`
- `meshguard upgrade`

---
*PR created automatically by Jules for task [10492436269268949134](https://jules.google.com/task/10492436269268949134) started by @igorls*