### PR TITLE
Add FreeBSD userspace WireGuard support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,6 +13,7 @@ pub fn build(b: *std.Build) void {
     const is_ios = resolved_os == .ios;
     const is_windows = resolved_os == .windows;
     const is_macos = resolved_os == .macos;
+    const is_freebsd = resolved_os == .freebsd;
 
     // ─── FFI module (for mobile embedding — not built on Windows) ───
     if (!is_windows) {
@@ -32,8 +33,8 @@ pub fn build(b: *std.Build) void {
         });
 
         // Link libsodium on Linux desktop targets for AVX2-accelerated crypto.
-        // On Android, macOS, iOS, and Windows, the Zig std.crypto software fallback is used.
-        if (!is_android and !is_macos and !is_ios) {
+        // On Android, macOS, iOS, FreeBSD, and Windows, the Zig std.crypto software fallback is used.
+        if (!is_android and !is_macos and !is_ios and !is_freebsd) {
             ffi_mod.linkSystemLibrary("sodium", .{});
         }
 
@@ -63,8 +64,8 @@ pub fn build(b: *std.Build) void {
             .root_module = exe_mod,
         });
         // Link libsodium on Linux desktop only (AVX2 ChaCha20-Poly1305 assembly)
-        // macOS and Windows use std.crypto
-        if (!is_windows and !is_macos) {
+        // macOS, FreeBSD, and Windows use std.crypto
+        if (!is_windows and !is_macos and !is_freebsd) {
             exe_mod.linkSystemLibrary("sodium", .{});
         }
         // On Windows, link ws2_32 for Winsock2 sockets
@@ -79,7 +80,7 @@ pub fn build(b: *std.Build) void {
         }
 
         // ─── WG interop test binary (Linux only — requires kernel WG) ───
-        if (!is_windows and !is_macos) {
+        if (!is_windows and !is_macos and !is_freebsd) {
             const interop_mod = b.createModule(.{
                 .root_source_file = b.path("src/wg_interop.zig"),
                 .target = target,
@@ -123,7 +124,7 @@ pub fn build(b: *std.Build) void {
         const unit_tests = b.addTest(.{
             .root_module = test_mod,
         });
-        if (!is_windows and !is_macos) {
+        if (!is_windows and !is_macos and !is_freebsd) {
             test_mod.linkSystemLibrary("sodium", .{});
         }
         if (is_windows) {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -9,6 +9,7 @@ const is_windows = builtin.os.tag == .windows;
 const is_macos = builtin.os.tag == .macos;
 const is_ios = builtin.os.tag == .ios;
 const is_darwin = is_macos or is_ios;
+const is_freebsd = builtin.os.tag == .freebsd;
 
 pub const identity = struct {
     pub const Keys = @import("identity/keys.zig");
@@ -55,10 +56,11 @@ pub const net = struct {
     pub const BatchUdp = if (is_linux) @import("net/batch_udp.zig") else struct {};
     pub const Offload = if (is_linux) @import("net/offload.zig") else struct {};
     pub const Io = @import("net/io.zig");
-    pub const Tun = if (is_linux) @import("net/tun.zig") else if (is_darwin) @import("net/utun.zig") else struct {};
+    pub const Tun = if (is_linux) @import("net/tun.zig") else if (is_darwin) @import("net/utun.zig") else if (is_freebsd) @import("net/fbsdtun.zig") else struct {};
     pub const Wintun = if (is_windows) @import("net/wintun.zig") else struct {};
     pub const WinCfg = if (is_windows) @import("net/wincfg.zig") else struct {};
     pub const DarwinCfg = if (is_darwin) @import("net/darwincfg.zig") else struct {};
+    pub const FreeBsdCfg = if (is_freebsd) @import("net/freebsdcfg.zig") else struct {};
     pub const Dns = @import("net/dns.zig");
     pub const Pipeline = @import("net/pipeline.zig");
     pub const IoUring = if (is_linux) @import("net/io_uring.zig") else struct {};

--- a/src/main.zig
+++ b/src/main.zig
@@ -788,7 +788,7 @@ fn cmdUp(allocator: std.mem.Allocator, extra_args: []const []const u8) !void {
     try stdout.writeStreamingAll(zio(), "meshguard starting...\n");
     try writeFormatted(stdout, "  mesh IP: {s}\n", .{ip_str});
     try writeFormatted(stdout, "  mesh IPv6: {s}/{d}\n", .{ ip6_str, lib.wireguard.Ip.default_mesh_mask6 });
-    try writeFormatted(stdout, "  interface: {s}\n", .{if (comptime @import("builtin").os.tag == .linux) lib.wireguard.Config.DEFAULT_IFNAME else if (comptime @import("builtin").os.tag == .macos) "utun" else "wintun"});
+    try writeFormatted(stdout, "  interface: {s}\n", .{if (comptime @import("builtin").os.tag == .linux) lib.wireguard.Config.DEFAULT_IFNAME else if (comptime @import("builtin").os.tag == .macos) "utun" else if (comptime @import("builtin").os.tag == .freebsd) "tun" else "wintun"});
 
     try writeFormatted(stdout, "  mode: {s}\n", .{if (use_kernel_wg) "kernel" else "userspace"});
 
@@ -1191,6 +1191,54 @@ fn cmdUp(allocator: std.mem.Allocator, extra_args: []const []const u8) !void {
             try stdout.writeStreamingAll(zio(), "  GSO/GRO offloads: not available (macOS)\n");
 
             // Run the macOS event loop (simplified, similar to Windows)
+            macosEventLoop(&swim, &wg_device, &gossip_socket, &tun_dev, stdout, &service_filter, &control) catch |err| {
+                try writeFormatted(stderr, "error: event loop failed: {s}\n", .{@errorName(err)});
+            };
+        } else if (comptime @import("builtin").os.tag == .freebsd) {
+            // ─── FreeBSD: tun(4) device + ifconfig/route config + poll-based event loop ───
+            const FreeBsdCfg = lib.net.FreeBsdCfg;
+
+            var tun_dev = lib.net.Tun.TunDevice.open("tun") catch |err| {
+                try writeFormatted(stderr, "error: failed to open tun device: {s}\n", .{@errorName(err)});
+                try stderr.writeStreamingAll(zio(), "  hint: run with sudo or ensure /dev/tun is accessible\n");
+                std.process.exit(1);
+            };
+            defer tun_dev.close();
+
+            try writeFormatted(stdout, "  TUN device: {s} (fd={d})\n", .{ tun_dev.getName(), tun_dev.fd });
+
+            // Configure IP address and routing
+            FreeBsdCfg.setInterfaceIp(allocator, tun_dev.getName(), mesh_ip, 16) catch |err| {
+                try writeFormatted(stderr, "warning: failed to set interface IP: {s}\n", .{@errorName(err)});
+            };
+            FreeBsdCfg.setInterfaceIp6(allocator, tun_dev.getName(), mesh_ip6, lib.wireguard.Ip.default_mesh_mask6) catch |err| {
+                try writeFormatted(stderr, "warning: failed to set interface IPv6: {s}\n", .{@errorName(err)});
+            };
+            FreeBsdCfg.setInterfaceUp(allocator, tun_dev.getName()) catch |err| {
+                try writeFormatted(stderr, "warning: failed to bring up interface: {s}\n", .{@errorName(err)});
+            };
+            FreeBsdCfg.setMtu(allocator, tun_dev.getName(), 1420) catch |err| {
+                try writeFormatted(stderr, "warning: failed to set MTU: {s}\n", .{@errorName(err)});
+            };
+            FreeBsdCfg.addRoute(allocator, tun_dev.getName(), .{ 10, 99, 0, 0 }, 16) catch |err| {
+                try writeFormatted(stderr, "warning: failed to add mesh route: {s}\n", .{@errorName(err)});
+            };
+            FreeBsdCfg.addRoute6(allocator, tun_dev.getName(), lib.wireguard.Ip.default_mesh_network6, lib.wireguard.Ip.default_mesh_mask6) catch |err| {
+                try writeFormatted(stderr, "warning: failed to add mesh IPv6 route: {s}\n", .{@errorName(err)});
+            };
+
+            try writeFormatted(stdout, "  mesh IP: {d}.{d}.{d}.{d}/16 (mtu=1420)\n", .{
+                mesh_ip[0], mesh_ip[1], mesh_ip[2], mesh_ip[3],
+            });
+
+            // Set TUN fd to non-blocking for the event loop
+            tun_dev.setNonBlocking() catch |err| {
+                try writeFormatted(stderr, "warning: failed to set TUN non-blocking: {s}\n", .{@errorName(err)});
+            };
+
+            try stdout.writeStreamingAll(zio(), "  GSO/GRO offloads: not available (FreeBSD)\n");
+
+            // Reuse macOS event loop — both are BSD with poll-based TunDevice API
             macosEventLoop(&swim, &wg_device, &gossip_socket, &tun_dev, stdout, &service_filter, &control) catch |err| {
                 try writeFormatted(stderr, "error: event loop failed: {s}\n", .{@errorName(err)});
             };

--- a/src/net/fbsdtun.zig
+++ b/src/net/fbsdtun.zig
@@ -1,0 +1,169 @@
+//! FreeBSD TUN device interface for userspace WireGuard.
+//!
+//! Opens the clone TUN device at /dev/tun and uses TUNGIFNAME to discover
+//! the kernel-assigned interface name.  FreeBSD's tun(4) prepends a 4-byte
+//! address-family header (like macOS utun), so read/write strip/add it.
+//!
+//! Note: we define FreeBSD ioctl constants manually rather than using
+//! @cImport to avoid @bitCast translation errors in cross-compilation.
+const std = @import("std");
+const posix = std.posix;
+
+// FreeBSD ioctl constants (from sys/ioccom.h, net/if_tun.h, net/if.h)
+// _IOR('t', 89, struct ifreq) — get tun interface name
+const TUNGIFNAME: c_ulong = 0x40107489;
+// _IOW('t', 96, int) — enable address-family header
+const TUNSIFHEAD: c_ulong = 0x80047460;
+// _IOW('i', 23, struct ifreq) — set interface MTU
+const SIOCSIFMTU: c_ulong = 0x80206934;
+
+pub const TunDevice = struct {
+    fd: posix.fd_t,
+    name: [16]u8,
+    name_len: usize,
+    /// FreeBSD tun(4) has no virtio-net header support; kept for API parity.
+    vnet_hdr: bool = false,
+
+    const HEADER_LEN: usize = 4; // AF family header prepended by tun(4)
+    const AF_INET: u32 = 2;
+
+    const Ifreq = extern struct {
+        ifr_name: [16]u8 = .{0} ** 16,
+        _pad: [24]u8 = .{0} ** 24,
+    };
+
+    pub fn open(name: []const u8) !TunDevice {
+        // FreeBSD's /dev/tun clone device assigns the actual interface name.
+        _ = name;
+        const fd = std.c.open("/dev/tun", .{ .ACCMODE = .RDWR });
+        switch (posix.errno(fd)) {
+            .SUCCESS => {},
+            else => |err| return posix.unexpectedErrno(err),
+        }
+        errdefer _ = std.c.close(fd);
+
+        // Set TUNSIFHEAD to get AF-family headers on read/write
+        const one: c_int = 1;
+        if (std.c.ioctl(fd, @as(c_int, @bitCast(@as(c_uint, @truncate(TUNSIFHEAD)))), &one) < 0)
+            return error.TunSetupFailed;
+
+        var ifr = Ifreq{};
+        const rc = std.c.ioctl(fd, @as(c_int, @bitCast(@as(c_uint, @truncate(TUNGIFNAME)))), &ifr);
+        if (rc < 0) return error.TunSetupFailed;
+
+        var name_len: usize = 0;
+        for (ifr.ifr_name) |ch| {
+            if (ch == 0) break;
+            name_len += 1;
+        }
+        if (name_len == 0) return error.TunSetupFailed;
+
+        return .{
+            .fd = fd,
+            .name = ifr.ifr_name,
+            .name_len = name_len,
+        };
+    }
+
+    /// Read an IP packet from the tun device.
+    /// Strips the 4-byte address-family header prepended by tun(4).
+    pub fn read(self: *TunDevice, buf: []u8) !usize {
+        var read_buf: [65536 + HEADER_LEN]u8 = undefined;
+        const max_read = @min(buf.len + HEADER_LEN, read_buf.len);
+
+        const n = posix.read(self.fd, read_buf[0..max_read]) catch |err| {
+            if (err == error.WouldBlock) return 0;
+            return err;
+        };
+
+        if (n <= HEADER_LEN) return 0;
+
+        const ip_len = n - HEADER_LEN;
+        @memcpy(buf[0..ip_len], read_buf[HEADER_LEN..][0..ip_len]);
+        return ip_len;
+    }
+
+    /// Write an IP packet to the tun device.
+    /// Prepends the 4-byte address-family header expected by tun(4).
+    pub fn write(self: *TunDevice, data: []const u8) !void {
+        // Detect IP version from first nibble
+        const af: u32 = if (data.len > 0 and (data[0] >> 4) == 6) 30 else AF_INET;
+
+        var hdr: [HEADER_LEN]u8 = undefined;
+        std.mem.writeInt(u32, &hdr, af, .big);
+        var iov = [_]posix.iovec_const{
+            .{ .base = &hdr, .len = HEADER_LEN },
+            .{ .base = data.ptr, .len = data.len },
+        };
+        if (std.c.writev(self.fd, &iov, iov.len) < 0) return error.WriteFailed;
+    }
+
+    pub fn setNonBlocking(self: *TunDevice) !void {
+        const flags = posix.system.fcntl(self.fd, posix.F.GETFL, @as(usize, 0));
+        switch (posix.errno(flags)) {
+            .SUCCESS => {},
+            else => |err| return posix.unexpectedErrno(err),
+        }
+
+        const rc = posix.system.fcntl(
+            self.fd,
+            posix.F.SETFL,
+            @as(usize, @intCast(flags)) | @as(usize, 1 << @bitOffsetOf(posix.O, "NONBLOCK")),
+        );
+        switch (posix.errno(rc)) {
+            .SUCCESS => {},
+            else => |err| return posix.unexpectedErrno(err),
+        }
+    }
+
+    pub fn getName(self: *const TunDevice) []const u8 {
+        return self.name[0..self.name_len];
+    }
+
+    pub fn setMtu(self: *const TunDevice, mtu: u32) !void {
+        const MtuIfreq = extern struct {
+            ifr_name: [16]u8 = .{0} ** 16,
+            ifr_mtu: i32 = 0,
+            _pad: [20]u8 = .{0} ** 20,
+        };
+
+        var ifr = MtuIfreq{};
+        @memcpy(ifr.ifr_name[0..self.name_len], self.name[0..self.name_len]);
+        ifr.ifr_mtu = @intCast(mtu);
+
+        const sock = std.c.socket(posix.AF.INET, posix.SOCK.DGRAM, 0);
+        switch (posix.errno(sock)) {
+            .SUCCESS => {},
+            else => |err| return posix.unexpectedErrno(err),
+        }
+        defer _ = std.c.close(sock);
+
+        const rc = std.c.ioctl(sock, @as(c_int, @bitCast(@as(c_uint, @truncate(SIOCSIFMTU)))), &ifr);
+        if (rc < 0) return error.SetMtuFailed;
+    }
+
+    pub fn close(self: *TunDevice) void {
+        _ = std.c.close(self.fd);
+    }
+
+    pub fn pollRead(self: *TunDevice, timeout_ms: i32) !bool {
+        var fds = [_]posix.pollfd{.{
+            .fd = self.fd,
+            .events = posix.POLL.IN,
+            .revents = 0,
+        }};
+        const n = try posix.poll(&fds, timeout_ms);
+        return n > 0 and (fds[0].revents & posix.POLL.IN != 0);
+    }
+
+    /// GSO/GRO offloads are not available on FreeBSD tun(4).
+    pub fn enableOffload(self: *TunDevice) void {
+        _ = self;
+    }
+
+    /// FreeBSD tun(4) does not support multi-queue.
+    pub fn openQueue(self: *const TunDevice) !TunDevice {
+        _ = self;
+        return error.Unsupported;
+    }
+};

--- a/src/net/freebsdcfg.zig
+++ b/src/net/freebsdcfg.zig
@@ -1,0 +1,120 @@
+//! FreeBSD network interface configuration for meshguard.
+//!
+//! Uses ifconfig/route commands to configure cloned tun(4) interfaces.
+//! Analogous to darwincfg.zig for macOS.
+const std = @import("std");
+
+fn zio() std.Io {
+    return std.Io.Threaded.global_single_threaded.io();
+}
+
+fn runCommand(argv: []const []const u8) !std.process.Child.Term {
+    var child = try std.process.spawn(zio(), .{
+        .argv = argv,
+        .stdin = .ignore,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    });
+    defer child.kill(zio());
+    return child.wait(zio());
+}
+
+/// Set the IPv4 address on a tun interface.
+/// Runs: ifconfig <iface> inet <ip> <ip> netmask <mask>
+pub fn setInterfaceIp(allocator: std.mem.Allocator, iface_name: []const u8, mesh_ip: [4]u8, prefix_len: u8) !void {
+    var ip_buf: [15]u8 = undefined;
+    const ip_str = formatIp(mesh_ip, &ip_buf);
+
+    var mask_buf: [15]u8 = undefined;
+    const mask_str = formatNetmask(prefix_len, &mask_buf);
+
+    _ = allocator;
+    const term = try runCommand(&.{ "ifconfig", iface_name, "inet", ip_str, ip_str, "netmask", mask_str });
+    if (term != .exited or term.exited != 0) return error.ConfigFailed;
+}
+
+/// Set an IPv6 address on a tun interface.
+/// Runs: ifconfig <iface> inet6 <ip> prefixlen <len>
+pub fn setInterfaceIp6(allocator: std.mem.Allocator, iface_name: []const u8, mesh_ip: [16]u8, prefix_len: u8) !void {
+    var ip_buf: [64]u8 = undefined;
+    const ip_str = formatIpv6(mesh_ip, &ip_buf);
+    var prefix_buf: [4]u8 = undefined;
+    const prefix_str = std.fmt.bufPrint(&prefix_buf, "{d}", .{prefix_len}) catch return error.ConfigFailed;
+
+    _ = allocator;
+    const term = try runCommand(&.{ "ifconfig", iface_name, "inet6", ip_str, "prefixlen", prefix_str });
+    if (term != .exited or term.exited != 0) return error.ConfigFailed;
+}
+
+/// Bring the interface up.
+pub fn setInterfaceUp(allocator: std.mem.Allocator, iface_name: []const u8) !void {
+    _ = allocator;
+    const term = try runCommand(&.{ "ifconfig", iface_name, "up" });
+    if (term != .exited or term.exited != 0) return error.ConfigFailed;
+}
+
+/// Set the MTU on an interface.
+pub fn setMtu(allocator: std.mem.Allocator, iface_name: []const u8, mtu: u32) !void {
+    var mtu_buf: [10]u8 = undefined;
+    const mtu_str = std.fmt.bufPrint(&mtu_buf, "{d}", .{mtu}) catch return error.ConfigFailed;
+
+    _ = allocator;
+    const term = try runCommand(&.{ "ifconfig", iface_name, "mtu", mtu_str });
+    if (term != .exited or term.exited != 0) return error.ConfigFailed;
+}
+
+/// Add a route for the mesh subnet via the interface.
+/// Runs: route add -net <network>/<prefix> -interface <iface>
+pub fn addRoute(allocator: std.mem.Allocator, iface_name: []const u8, network: [4]u8, prefix_len: u8) !void {
+    var net_buf: [18]u8 = undefined;
+    var ip_buf: [15]u8 = undefined;
+    const ip_str = formatIp(network, &ip_buf);
+    const net_str = std.fmt.bufPrint(&net_buf, "{s}/{d}", .{ ip_str, prefix_len }) catch return error.ConfigFailed;
+
+    _ = allocator;
+    // Route may already exist — don't fail
+    _ = try runCommand(&.{ "route", "add", "-net", net_str, "-interface", iface_name });
+}
+
+/// Add an IPv6 route via the interface.
+/// Runs: route add -inet6 <network>/<prefix> -interface <iface>
+pub fn addRoute6(allocator: std.mem.Allocator, iface_name: []const u8, network: [16]u8, prefix_len: u8) !void {
+    var net_buf: [80]u8 = undefined;
+    var ip_buf: [64]u8 = undefined;
+    const ip_str = formatIpv6(network, &ip_buf);
+    const net_str = std.fmt.bufPrint(&net_buf, "{s}/{d}", .{ ip_str, prefix_len }) catch return error.ConfigFailed;
+
+    _ = allocator;
+    _ = try runCommand(&.{ "route", "add", "-inet6", net_str, "-interface", iface_name });
+}
+
+/// Bring the interface down.
+pub fn setInterfaceDown(allocator: std.mem.Allocator, iface_name: []const u8) !void {
+    _ = allocator;
+    _ = try runCommand(&.{ "ifconfig", iface_name, "down" });
+}
+
+// ─── Helpers ───
+
+fn formatIp(ip: [4]u8, buf: *[15]u8) []const u8 {
+    const result = std.fmt.bufPrint(buf, "{d}.{d}.{d}.{d}", .{ ip[0], ip[1], ip[2], ip[3] }) catch return "0.0.0.0";
+    return result;
+}
+
+fn formatNetmask(prefix_len: u8, buf: *[15]u8) []const u8 {
+    const mask: u32 = if (prefix_len >= 32) 0xFFFFFFFF else (@as(u32, 0xFFFFFFFF) << @intCast(32 - @as(u6, @intCast(prefix_len))));
+    const result = std.fmt.bufPrint(buf, "{d}.{d}.{d}.{d}", .{
+        @as(u8, @truncate(mask >> 24)),
+        @as(u8, @truncate(mask >> 16)),
+        @as(u8, @truncate(mask >> 8)),
+        @as(u8, @truncate(mask)),
+    }) catch return "255.255.0.0";
+    return result;
+}
+
+fn formatIpv6(ip: [16]u8, buf: []u8) []const u8 {
+    return std.fmt.bufPrint(buf, "{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}", .{
+        ip[0], ip[1], ip[2], ip[3], ip[4], ip[5], ip[6], ip[7],
+        ip[8], ip[9], ip[10], ip[11], ip[12], ip[13], ip[14], ip[15],
+    }) catch "::";
+}

--- a/src/net/udp.zig
+++ b/src/net/udp.zig
@@ -1,5 +1,5 @@
 //! UDP socket abstraction for meshguard gossip.
-//! Cross-platform: Linux (syscalls), Windows (Winsock2).
+//! Cross-platform: Linux (syscalls), Windows (Winsock2), macOS/FreeBSD (BSD sockets).
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -8,6 +8,8 @@ const is_linux = builtin.os.tag == .linux;
 const is_macos = builtin.os.tag == .macos;
 const is_ios = builtin.os.tag == .ios;
 const is_darwin = is_macos or is_ios;
+const is_freebsd = builtin.os.tag == .freebsd;
+const is_bsd = is_darwin or is_freebsd;
 const posix = std.posix;
 const messages = @import("../protocol/messages.zig");
 
@@ -83,7 +85,7 @@ pub const UdpSocket = struct {
             }
         } else {
             try posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.REUSEADDR, std.mem.asBytes(&one));
-            if (comptime is_darwin) {
+            if (comptime is_bsd) {
                 const SO_REUSEPORT: u32 = 0x0200;
                 posix.setsockopt(fd, posix.SOL.SOCKET, SO_REUSEPORT, std.mem.asBytes(&one)) catch {};
             }
@@ -358,8 +360,8 @@ pub const UdpSocket = struct {
     /// Poll the socket for readability with a timeout (milliseconds).
     /// Returns true if data is available.
     pub fn pollRead(self: UdpSocket, timeout_ms: i32) !bool {
-        if (comptime is_linux or is_darwin) {
-            // Use std.posix.poll — works on Linux, macOS, iOS, and Android
+        if (comptime is_linux or is_bsd) {
+            // Use std.posix.poll — works on Linux, macOS, iOS, FreeBSD, and Android
             // without requiring C headers (critical for iOS cross-compilation).
             const POLLIN: i16 = 0x0001;
             var fds = [1]std.posix.pollfd{.{


### PR DESCRIPTION
Properly implements FreeBSD support on top of the IPv6 merge (#97).

## Changes (6 files, +354/-12)

**New files:**
- `src/net/fbsdtun.zig` — FreeBSD tun(4) clone device with TUNSIFHEAD AF-family headers. Uses manual ioctl constants (TUNGIFNAME=0x40107489, TUNSIFHEAD=0x80047460, SIOCSIFMTU=0x80206934) to avoid `@cImport` cross-compilation failures (`@bitCast` in translated C macros).
- `src/net/freebsdcfg.zig` — Network configuration via `ifconfig`/`route` commands using proper `std.process.spawn` API. Full IPv4/IPv6 address, route, MTU, and interface up/down management matching the `darwincfg.zig` pattern.

**Modified files:**
- `build.zig` — FreeBSD target detection; excluded from libsodium linkage and kernel WG interop test
- `src/lib.zig` — Conditional module wiring: `Tun → fbsdtun.zig`, `FreeBsdCfg → freebsdcfg.zig`
- `src/net/udp.zig` — Extended `SO_REUSEPORT` (0x0200) and `pollRead` to FreeBSD via `is_bsd` flag
- `src/main.zig` — FreeBSD event loop branch reusing macOS poll-based loop (both BSD, identical TunDevice API)

## Validation
- ✅ Native Linux build (`zig build`)
- ✅ Native Linux tests (`zig build test`)
- ✅ FreeBSD cross-compilation (`zig build -Dtarget=x86_64-freebsd`)

Supersedes #98 (closed — reverted IPv6, used hallucinated APIs).