### PR TITLE
feat(crypto): make libsodium a build-selectable optional backend (#102)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,9 +22,17 @@ pub fn build(b: *std.Build) void {
     //   std    → std.crypto everywhere (no libsodium link)
     //   sodium → force libsodium (link must be available for the target)
     const CryptoBackend = enum { auto, std, sodium };
-    const crypto_backend = b.option(CryptoBackend, "crypto-backend", "Crypto backend: auto|std|sodium (default auto)") orelse .auto;
+    const crypto_backend_opt = b.option(CryptoBackend, "crypto-backend", "Crypto backend: auto|std|sodium (default auto)");
     // Back-compat alias: -Dno-sodium=true is equivalent to -Dcrypto-backend=std.
     const no_sodium = b.option(bool, "no-sodium", "Alias for -Dcrypto-backend=std") orelse false;
+
+    // Fail fast on contradictory flags rather than silently letting one win.
+    if (no_sodium and (crypto_backend_opt orelse .std) == .sodium) {
+        std.debug.print("error: -Dno-sodium=true conflicts with -Dcrypto-backend=sodium\n" ++
+            "  (-Dno-sodium is an alias for -Dcrypto-backend=std)\n", .{});
+        std.process.exit(1);
+    }
+    const crypto_backend = crypto_backend_opt orelse .auto;
 
     // libsodium is only auto-selected on Linux desktop (non-Android), where the
     // vendored/system .so provides the AVX2 assembly. Everywhere else → std.crypto.

--- a/build.zig
+++ b/build.zig
@@ -15,12 +15,32 @@ pub fn build(b: *std.Build) void {
     const is_macos = resolved_os == .macos;
     const is_freebsd = resolved_os == .freebsd;
 
-    // Build option: disable libsodium linkage (for cross-compilation CI where
-    // the target arch's libsodium is not available). Falls back to std.crypto.
-    const no_sodium = b.option(bool, "no-sodium", "Disable libsodium linkage (use std.crypto)") orelse false;
+    // ─── Crypto backend selection (meshguard#102) ───
+    // libsodium is an OPTIONAL accelerator (AVX2 ChaCha20-Poly1305 on Linux),
+    // not a required dependency. std.crypto is the portable fallback.
+    //   auto   → libsodium on Linux desktop (non-Android), std.crypto elsewhere
+    //   std    → std.crypto everywhere (no libsodium link)
+    //   sodium → force libsodium (link must be available for the target)
+    const CryptoBackend = enum { auto, std, sodium };
+    const crypto_backend = b.option(CryptoBackend, "crypto-backend", "Crypto backend: auto|std|sodium (default auto)") orelse .auto;
+    // Back-compat alias: -Dno-sodium=true is equivalent to -Dcrypto-backend=std.
+    const no_sodium = b.option(bool, "no-sodium", "Alias for -Dcrypto-backend=std") orelse false;
 
-    // Platforms that never use libsodium
-    const skip_sodium = no_sodium or is_android or is_macos or is_ios or is_freebsd;
+    // libsodium is only auto-selected on Linux desktop (non-Android), where the
+    // vendored/system .so provides the AVX2 assembly. Everywhere else → std.crypto.
+    const auto_libsodium = (resolved_os == .linux and resolved_abi != .android);
+    const use_libsodium = if (no_sodium) false else switch (crypto_backend) {
+        .std => false,
+        .sodium => true,
+        .auto => auto_libsodium,
+    };
+
+    // Exposed to source via @import("build_options") so tunnel.zig / main.zig
+    // select the same backend the linker is wired for. Without this the source
+    // chose the backend from builtin.os.tag alone and ignored the build option.
+    const build_options = b.addOptions();
+    build_options.addOption(bool, "use_libsodium", use_libsodium);
+    const build_options_mod = build_options.createModule();
 
     // ─── FFI module (for mobile embedding — not built on Windows) ───
     if (!is_windows) {
@@ -31,6 +51,7 @@ pub fn build(b: *std.Build) void {
             .link_libc = true,
             .strip = if (is_android) true else null,
         });
+        ffi_mod.addImport("build_options", build_options_mod);
 
         const ffi_lib = b.addLibrary(.{
             .name = "meshguard-ffi",
@@ -39,9 +60,9 @@ pub fn build(b: *std.Build) void {
             .linkage = if (is_ios) .static else .dynamic,
         });
 
-        // Link libsodium on Linux desktop targets for AVX2-accelerated crypto.
-        // On Android, macOS, iOS, FreeBSD, and Windows, the Zig std.crypto software fallback is used.
-        if (!skip_sodium) {
+        // Link libsodium only when the resolved backend uses it (Linux desktop).
+        // Otherwise the Zig std.crypto software path is used (no link needed).
+        if (use_libsodium) {
             ffi_mod.linkSystemLibrary("sodium", .{});
         }
 
@@ -57,6 +78,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .link_libc = true,
         });
+        exe_mod.addImport("build_options", build_options_mod);
 
         const lib_mod = b.createModule(.{
             .root_source_file = b.path("src/lib.zig"),
@@ -64,15 +86,16 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .link_libc = true,
         });
+        lib_mod.addImport("build_options", build_options_mod);
 
         // ─── Main executable ───
         const exe = b.addExecutable(.{
             .name = "meshguard",
             .root_module = exe_mod,
         });
-        // Link libsodium on Linux desktop only (AVX2 ChaCha20-Poly1305 assembly)
-        // macOS, FreeBSD, and Windows use std.crypto
-        if (!is_windows and !skip_sodium) {
+        // Link libsodium only when the resolved backend uses it (Linux desktop,
+        // AVX2 ChaCha20-Poly1305 assembly). std.crypto everywhere else.
+        if (use_libsodium) {
             exe_mod.linkSystemLibrary("sodium", .{});
         }
         // On Windows, link ws2_32 for Winsock2 sockets
@@ -94,11 +117,12 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
                 .link_libc = true,
             });
+            interop_mod.addImport("build_options", build_options_mod);
             const interop_exe = b.addExecutable(.{
                 .name = "wg-interop-test",
                 .root_module = interop_mod,
             });
-            if (!skip_sodium) {
+            if (use_libsodium) {
                 interop_mod.linkSystemLibrary("sodium", .{});
             }
             b.installArtifact(interop_exe);
@@ -128,11 +152,12 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .link_libc = true,
         });
+        test_mod.addImport("build_options", build_options_mod);
 
         const unit_tests = b.addTest(.{
             .root_module = test_mod,
         });
-        if (!is_windows and !skip_sodium) {
+        if (use_libsodium) {
             test_mod.linkSystemLibrary("sodium", .{});
         }
         if (is_windows) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -111,9 +111,9 @@ pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
     const arena = init.arena.allocator();
 
-    // Initialize libsodium (AVX2 ChaCha20-Poly1305 assembly) — Linux only
-    // macOS and Windows use std.crypto (no libsodium dependency)
-    if (comptime @import("builtin").os.tag == .linux) {
+    // Initialize libsodium (AVX2 ChaCha20-Poly1305 assembly) only when the
+    // resolved backend uses it. std.crypto path needs no init (meshguard#102).
+    if (comptime @import("build_options").use_libsodium) {
         @import("crypto/sodium.zig").init();
     }
 

--- a/src/wireguard/tunnel.zig
+++ b/src/wireguard/tunnel.zig
@@ -11,11 +11,12 @@
 const std = @import("std");
 const noise = @import("noise.zig");
 
-// Compile-time AEAD backend selection:
-// - Linux/native (non-Android): libsodium (AVX2 assembly, ~2× faster)
-// - Android/Windows/other: std.crypto (no libsodium dependency)
-const builtin = @import("builtin");
-const use_libsodium = (builtin.os.tag == .linux and builtin.target.abi != .android);
+// Compile-time AEAD backend selection, resolved in build.zig and passed in via
+// build_options so the source and the linker always agree (meshguard#102).
+// Default (auto): libsodium on Linux desktop (AVX2 assembly, ~2× faster at MTU/
+// bulk), std.crypto everywhere else. -Dcrypto-backend=std / -Dno-sodium forces
+// the std.crypto path on Linux too (no libsodium link required).
+const use_libsodium = @import("build_options").use_libsodium;
 
 /// Returns a blocking Io instance for synchronous operations.
 fn zio() std.Io {


### PR DESCRIPTION
## Summary

Makes `-Dno-sodium` / `-Dcrypto-backend` actually reach the source, so MeshGuard can build with `std.crypto` and **no libsodium** — addresses #102.

Previously the build option only controlled *linkage*: `tunnel.zig` and `main.zig` chose the AEAD backend from `builtin.os.tag` alone, so `-Dno-sodium=true` on Linux skipped linking libsodium yet still compiled the sodium path → unresolved symbols at link time. The flag was effectively a no-op (or broke the build) on Linux.

## Changes

- Add a `build_options` module exposing `use_libsodium`, resolved in `build.zig` from a new `-Dcrypto-backend=auto|std|sodium` (with `-Dno-sodium` kept as a `std` alias), and thread it into every module (ffi, exe, lib, interop, test).
- `tunnel.zig` and `main.zig` now read `build_options.use_libsodium` instead of `builtin.os.tag`, so source and linker always agree. Linkage collapses to a single `if (use_libsodium)`.
- `auto` preserves prior behaviour: libsodium on Linux desktop (non-Android), `std.crypto` everywhere else.

## Verification

- Builds across backends on macOS: default / `-Dno-sodium=true` / `-Dcrypto-backend=std`.
- **`zig build -Dtarget=x86_64-linux-gnu -Dno-sodium=true`** → builds cleanly with `std.crypto`, no libsodium (the acceptance criterion that previously failed at link time).
- Sodium path still compiles **and runs**: `zig build test -Dcrypto-backend=sodium` (linking system libsodium) → 40/40 tests pass, including the tunnel encrypt/decrypt roundtrip through libsodium.

## Acceptance criteria (#102)

- [x] Build/test with `std.crypto` on Linux without libsodium installed
- [x] Still build with libsodium acceleration when requested/available
- [x] Downstream packages can force the no-sodium path without patching MeshGuard source (wormdb's `build.zig` passes `use_libsodium` through to the embedded module)
- [x] Benchmarks compare libsodium vs std.crypto (run downstream; libsodium ~2× MTU / ~3× bulk on x86_64 AVX2, ~1.2× ARM, slightly slower at gossip sizes)
- [ ] CI: a no-sodium Linux build/test job (follow-up)
- [ ] Docs: a dedicated section describing libsodium as optional acceleration (this PR adds the build-option help text + comments)
