### PR TITLE
fix(net/udp): raw syscall -errno used as a length (OOB); + FFI flood hardening

### DIFF
--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -58,6 +58,13 @@ const PendingPing = struct {
     escalated: bool, // whether we've already sent ping-req
 };
 
+/// Hard ceiling on SWIM control-plane send rate (packets/sec). Legitimate
+/// gossip needs only a handful of pps even in a large mesh; this is generous
+/// headroom while still bounding any flood to a level a router shrugs off.
+const SEND_RATE_PPS: f64 = 500.0;
+/// Token-bucket capacity (allowed short burst above the sustained rate).
+const SEND_BURST: f64 = 100.0;
+
 /// SWIM protocol state machine with event loop.
 pub const SwimProtocol = struct {
     config: SwimConfig,
@@ -123,11 +130,21 @@ pub const SwimProtocol = struct {
     // Node's own org certificate (if any, loaded at init)
     our_org_cert: ?[186]u8 = null,
 
+    // Control-plane send rate limiting (token bucket). A hard ceiling on
+    // SWIM/gossip packets/sec so a pathological inbound rate (e.g. a NAT
+    // retransmit storm) can never be amplified into a network-melting flood.
+    // Tunnel DATA does NOT pass through here — it uses the socket directly via
+    // the FFI layer — so egress throughput is unaffected by this cap.
+    send_tokens: f64 = SEND_BURST,
+    last_token_refill_ns: i128 = 0,
+
     // Debug counters
     pkts_sent: u32 = 0,
     pkts_recv: u32 = 0,
     raw_recv: u32 = 0,
     tick_count: u32 = 0,
+    acks_sent: u32 = 0,
+    sends_dropped_ratelimit: u32 = 0,
 
     // Liveness tracking: timestamp of last received packet (epoch nanoseconds, i64)
     last_recv_ns: std.atomic.Value(i64) = std.atomic.Value(i64).init(0),
@@ -267,7 +284,7 @@ pub const SwimProtocol = struct {
             const peer = entry.value_ptr;
             if (peer.state == .alive or peer.state == .suspected) {
                 if (peer.gossip_endpoint) |ep| {
-                    _ = self.socket.sendToEndpoint(buf[0..written], ep) catch {};
+                    self.gossipSend(buf[0..written], ep);
                 }
             }
         }
@@ -517,29 +534,18 @@ pub const SwimProtocol = struct {
                     cb(h.ctx, data);
                 }
             }
-            std.debug.print("  📨 APP msg delivered locally ({d}B)\n", .{data.len});
             return;
         }
 
-        // Not for us — relay to destination peer
+        // Not for us — relay to destination peer (rate-limited; no per-message
+        // logging in this hot path).
         var dest_key: [32]u8 = undefined;
         @memcpy(&dest_key, dest_pubkey);
-        const peer = self.membership.peers.get(dest_key) orelse {
-            std.debug.print("  📨 APP msg relay FAILED: unknown dest\n", .{});
-            return;
-        };
-        const ep = peer.gossip_endpoint orelse {
-            std.debug.print("  📨 APP msg relay FAILED: no endpoint\n", .{});
-            return;
-        };
+        const peer = self.membership.peers.get(dest_key) orelse return;
+        const ep = peer.gossip_endpoint orelse return;
 
         // Forward the entire message as-is (encrypted, we can't read it)
-        _ = self.socket.sendToEndpoint(data, ep) catch {
-            std.debug.print("  📨 APP msg relay FAILED: sendTo error\n", .{});
-            return;
-        };
-        var ep_buf: [64]u8 = undefined;
-        std.debug.print("  📨 APP msg relayed ({d}B) → {s}\n", .{ data.len, ep.format(&ep_buf) });
+        self.gossipSend(data, ep);
     }
 
     /// Verify an org control message before acting on it.
@@ -695,14 +701,12 @@ pub const SwimProtocol = struct {
 
         var buf: [1500]u8 = undefined;
         const written = codec.encodeAck(&buf, ack) catch return;
-        const send_result = self.socket.sendToEndpoint(buf[0..written], sender_endpoint);
-        if (send_result) |bytes| {
-            var ep_buf: [64]u8 = undefined;
-            std.debug.print("  ACK sent ({d}B) → {s}\n", .{ bytes, sender_endpoint.format(&ep_buf) });
-        } else |err| {
-            var ep_buf: [64]u8 = undefined;
-            std.debug.print("  ACK FAILED → {s} err={s}\n", .{ sender_endpoint.format(&ep_buf), @errorName(err) });
-        }
+        // Rate-limited send, no per-packet logging: an unconditional
+        // std.debug.print here (one stderr syscall per inbound PING) was the
+        // CPU sink that, under a NAT retransmit storm, pegged a core and helped
+        // melt the LAN. Count instead.
+        self.gossipSend(buf[0..written], sender_endpoint);
+        self.acks_sent +%= 1;
     }
 
     fn handleAck(self: *SwimProtocol, ack: *const codec.DecodedAck, sender_endpoint: messages.Endpoint) void {
@@ -746,7 +750,7 @@ pub const SwimProtocol = struct {
                 var buf: [128]u8 = undefined;
                 const written = codec.encodeHolepunchResponse(&buf, resp) catch return;
                 // Send response back through the rendezvous (sender)
-                _ = self.socket.sendToEndpoint(buf[0..written], sender_endpoint) catch {};
+                self.gossipSend(buf[0..written], sender_endpoint);
 
                 // Also start probing the initiator's endpoint
                 _ = self.holepuncher.initiate(self.our_pubkey, req.sender_pubkey, our_ep);
@@ -764,7 +768,7 @@ pub const SwimProtocol = struct {
                 if (target.gossip_endpoint) |ep| {
                     var buf: [128]u8 = undefined;
                     const written = codec.encodeHolepunchRequest(&buf, req) catch return;
-                    _ = self.socket.sendToEndpoint(buf[0..written], ep) catch {};
+                    self.gossipSend(buf[0..written], ep);
                 }
             }
         }
@@ -840,7 +844,7 @@ pub const SwimProtocol = struct {
                     std.debug.print("  [punch] initiating punch to {x:0>2}{x:0>2}... via rendezvous\n", .{ peer.pubkey[0], peer.pubkey[1] });
                     var buf: [128]u8 = undefined;
                     const written = codec.encodeHolepunchRequest(&buf, req) catch continue;
-                    _ = self.socket.sendToEndpoint(buf[0..written], rvz_ep) catch {};
+                    self.gossipSend(buf[0..written], rvz_ep);
                 }
             }
         }
@@ -919,6 +923,26 @@ pub const SwimProtocol = struct {
 
     // ─── PING/timeout management ───
 
+    /// Rate-limited control-plane send (token bucket). ALL SWIM gossip/ping/
+    /// ack/ping-req/holepunch/relay traffic goes through here so it can never
+    /// be amplified into a flood. Over-budget packets are dropped (counted),
+    /// which is correct for an unreliable gossip protocol. Tunnel DATA does not
+    /// use this path, so egress throughput is unaffected.
+    fn gossipSend(self: *SwimProtocol, data: []const u8, endpoint: messages.Endpoint) void {
+        const now = nowNs();
+        if (self.last_token_refill_ns == 0) self.last_token_refill_ns = now;
+        const elapsed_s: f64 = @as(f64, @floatFromInt(now - self.last_token_refill_ns)) / 1_000_000_000.0;
+        self.last_token_refill_ns = now;
+        self.send_tokens = @min(SEND_BURST, self.send_tokens + elapsed_s * SEND_RATE_PPS);
+        if (self.send_tokens < 1.0) {
+            self.sends_dropped_ratelimit +%= 1;
+            return; // over budget — drop to protect the network
+        }
+        self.send_tokens -= 1.0;
+        _ = self.socket.sendToEndpoint(data, endpoint) catch return;
+        self.pkts_sent +%= 1;
+    }
+
     fn sendPing(self: *SwimProtocol, endpoint: messages.Endpoint, target_pubkey: [32]u8) void {
         self.seq += 1;
         const gossip = self.collectGossip();
@@ -931,8 +955,7 @@ pub const SwimProtocol = struct {
 
         var buf: [1500]u8 = undefined;
         const written = codec.encodePing(&buf, ping) catch return;
-        _ = self.socket.sendToEndpoint(buf[0..written], endpoint) catch return;
-        self.pkts_sent += 1;
+        self.gossipSend(buf[0..written], endpoint);
 
         // Track pending
         if (self.pending_count < self.pending.len) {
@@ -1008,7 +1031,7 @@ pub const SwimProtocol = struct {
 
             var buf: [128]u8 = undefined;
             const written = codec.encodePingReq(&buf, req) catch continue;
-            _ = self.socket.sendToEndpoint(buf[0..written], ep) catch continue;
+            self.gossipSend(buf[0..written], ep);
             sent += 1;
         }
     }

--- a/src/meshguard_ffi.zig
+++ b/src/meshguard_ffi.zig
@@ -242,6 +242,27 @@ export fn meshguard_init_ipv6(
     return ctx;
 }
 
+/// Initialize, binding the UDP socket to a SPECIFIC local IPv4 address instead
+/// of INADDR_ANY. On a multi-homed / public-IP host this binds the daemon only
+/// to the intended interface, so it never listens on or sources traffic from
+/// LAN interfaces. `bind_ip`: 4 address bytes (e.g. {187,16,79,234}).
+/// Returns the context, or null on failure.
+export fn meshguard_init_bind(
+    identity_seed: ?[*]const u8,
+    listen_port: u16,
+    bind_ip: [*]const u8,
+) ?*MeshguardContext {
+    const ctx = meshguard_init(identity_seed, listen_port) orelse return null;
+    if (ctx.socket) |*s| s.close();
+    var addr: [4]u8 = undefined;
+    @memcpy(&addr, bind_ip[0..4]);
+    ctx.socket = Udp.UdpSocket.bindAddr(addr, listen_port) catch {
+        ctx.alloc.destroy(ctx);
+        return null;
+    };
+    return ctx;
+}
+
 /// Destroy a meshguard instance, stopping all networking.
 export fn meshguard_destroy(ctx: ?*MeshguardContext) void {
     const c = ctx orelse return;
@@ -982,10 +1003,36 @@ export fn meshguard_join_host(
 
 fn eventLoop(ctx: *MeshguardContext) void {
     var lan_beacon_counter: u32 = 0;
+    // Opt-in diagnostics (MESHGUARD_STATS=1): once-per-second counter deltas, so
+    // we can see WHICH path is hot (tick spin vs inbound flood vs rate-cap drops
+    // vs hole-punch) without per-packet logging. No-op unless the env var is set.
+    const stats_enabled = std.c.getenv("MESHGUARD_STATS") != null;
+    var last_stats_ns: i128 = 0;
+    var s_tick: u32 = 0;
+    var s_recv: u32 = 0;
+    var s_sent: u32 = 0;
+    var s_raw: u32 = 0;
+    var s_drop: u32 = 0;
     while (ctx.running.load(.acquire)) {
         const is_suspended = ctx.suspended.load(.acquire);
 
         if (ctx.swim) |*swim| {
+            if (stats_enabled) {
+                const now: i128 = @intCast(std.Io.Timestamp.now(zio(), .awake).toNanoseconds());
+                if (now - last_stats_ns >= 1_000_000_000) {
+                    last_stats_ns = now;
+                    std.debug.print("[stats] tick/s={d} recv/s={d} sent/s={d} raw/s={d} dropped/s={d} punches={d}\n", .{
+                        swim.tick_count -% s_tick,    swim.pkts_recv -% s_recv,
+                        swim.pkts_sent -% s_sent,     swim.raw_recv -% s_raw,
+                        swim.sends_dropped_ratelimit -% s_drop, swim.holepuncher.activeCount(),
+                    });
+                    s_tick = swim.tick_count;
+                    s_recv = swim.pkts_recv;
+                    s_sent = swim.pkts_sent;
+                    s_raw = swim.raw_recv;
+                    s_drop = swim.sends_dropped_ratelimit;
+                }
+            }
             if (is_suspended) {
                 // SUSPENDED: receive-only mode
                 // - Poll socket for incoming packets (messages, SOS, handshakes)

--- a/src/meshguard_ffi.zig
+++ b/src/meshguard_ffi.zig
@@ -250,12 +250,15 @@ export fn meshguard_init_ipv6(
 export fn meshguard_init_bind(
     identity_seed: ?[*]const u8,
     listen_port: u16,
-    bind_ip: [*]const u8,
+    bind_ip: ?[*]const u8,
 ) ?*MeshguardContext {
+    // C-ABI entrypoint: a caller can pass NULL. Null-check before any deref or
+    // allocation so a bad pointer fails cleanly instead of crashing in @memcpy.
+    const ip_ptr = bind_ip orelse return null;
     const ctx = meshguard_init(identity_seed, listen_port) orelse return null;
     if (ctx.socket) |*s| s.close();
     var addr: [4]u8 = undefined;
-    @memcpy(&addr, bind_ip[0..4]);
+    @memcpy(&addr, ip_ptr[0..4]);
     ctx.socket = Udp.UdpSocket.bindAddr(addr, listen_port) catch {
         ctx.alloc.destroy(ctx);
         return null;

--- a/src/net/udp.zig
+++ b/src/net/udp.zig
@@ -246,10 +246,12 @@ pub const UdpSocket = struct {
         const addr = makeSockaddrIn(dest_addr, dest_port);
         if (comptime is_linux) {
             const rc = linux.sendto(self.fd, data.ptr, data.len, 0, @ptrCast(&addr), @sizeOf(@TypeOf(addr)));
-            switch (posix.errno(rc)) {
-                .SUCCESS => {},
-                else => |err| return posix.unexpectedErrno(err),
-            }
+            // Raw syscall returns -errno; libc-mode posix.errno() misses it (only
+            // catches -1), so a failed send returned -errno AS the byte count
+            // (the bogus "ACK sent (-11 bytes)" logs). Check the sign directly:
+            // any error (EAGAIN/ENOBUFS/unreachable) is a clean drop for UDP.
+            const sgn: isize = @bitCast(rc);
+            if (sgn < 0) return error.WouldBlock;
             return @intCast(rc);
         } else if (comptime is_windows) {
             const n = std.c.sendto(self.fd, data.ptr, data.len, 0, @ptrCast(&addr), @sizeOf(@TypeOf(addr)));
@@ -267,10 +269,8 @@ pub const UdpSocket = struct {
         const addr = makeSockaddrIn6(dest_addr, dest_port);
         if (comptime is_linux) {
             const rc = linux.sendto(self.fd, data.ptr, data.len, 0, @ptrCast(&addr), @sizeOf(@TypeOf(addr)));
-            switch (posix.errno(rc)) {
-                .SUCCESS => {},
-                else => |err| return posix.unexpectedErrno(err),
-            }
+            const sgn: isize = @bitCast(rc); // raw -errno; check sign (see sendTo)
+            if (sgn < 0) return error.WouldBlock;
             return @intCast(rc);
         } else {
             const n = std.c.sendto(self.fd, data.ptr, data.len, 0, @ptrCast(&addr), @sizeOf(@TypeOf(addr)));
@@ -294,12 +294,17 @@ pub const UdpSocket = struct {
 
         if (comptime is_linux) {
             const rc = linux.recvfrom(self.fd, buf.ptr, buf.len, 0, @ptrCast(&src_addr), &addr_len);
-            switch (posix.errno(rc)) {
-                .SUCCESS => {},
-                .AGAIN => return null,
-                else => |err| return posix.unexpectedErrno(err),
-            }
+            // CRITICAL: linux.recvfrom is a RAW syscall that returns -errno on
+            // error (EAGAIN=-11, etc.). With libc linked, std.posix.errno() only
+            // classifies rv==-1, so every other -errno slipped through as
+            // .SUCCESS and got @intCast into a huge length → buf[0..huge] OOB
+            // (silent memory corruption in ReleaseFast → the 2026-06-10 segfault
+            // on debug builds and the CPU hang on the deploy host). Check the
+            // raw return's sign directly instead of trusting posix.errno.
+            const sgn: isize = @bitCast(rc);
+            if (sgn < 0) return null; // no datagram (EAGAIN) or transient error
             const n: usize = @intCast(rc);
+            if (n > buf.len) return null; // paranoia: never slice past the buffer
 
             // Extract sender IP and port
             const ip_bytes: [4]u8 = @bitCast(src_addr.addr);
@@ -332,12 +337,11 @@ pub const UdpSocket = struct {
 
         if (comptime is_linux) {
             const rc = linux.recvfrom(self.fd, buf.ptr, buf.len, 0, @ptrCast(&src_addr), &addr_len);
-            switch (posix.errno(rc)) {
-                .SUCCESS => {},
-                .AGAIN => return null,
-                else => |err| return posix.unexpectedErrno(err),
-            }
+            // Raw syscall returns -errno; check sign directly (see recvFrom).
+            const sgn: isize = @bitCast(rc);
+            if (sgn < 0) return null;
             const n: usize = @intCast(rc);
+            if (n > buf.len) return null;
             return RecvResult{
                 .data = buf[0..n],
                 .sender_addr = .{0} ** 4,
@@ -364,6 +368,8 @@ pub const UdpSocket = struct {
             // Use std.posix.poll — works on Linux, macOS, iOS, FreeBSD, and Android
             // without requiring C headers (critical for iOS cross-compilation).
             const POLLIN: i16 = 0x0001;
+            const POLLERR: i16 = 0x0008;
+            const POLLHUP: i16 = 0x0010;
             var fds = [1]std.posix.pollfd{.{
                 .fd = self.fd,
                 .events = POLLIN,
@@ -371,7 +377,12 @@ pub const UdpSocket = struct {
             }};
 
             _ = try std.posix.poll(&fds, timeout_ms);
-            return (fds[0].revents & POLLIN) != 0;
+            // Defensive: surface POLLERR/POLLHUP too, not just POLLIN. A pending
+            // socket error condition makes poll() return immediately and
+            // persistently; if we only checked POLLIN we'd return false forever,
+            // recvFrom would never run to drain the error, and a no-sleep event
+            // loop above could hot-spin. Returning true lets recvFrom consume it.
+            return (fds[0].revents & (POLLIN | POLLERR | POLLHUP)) != 0;
         } else if (comptime is_windows) {
             var fds = [1]win.pollfd{.{
                 .fd = self.fd,

--- a/src/net/udp.zig
+++ b/src/net/udp.zig
@@ -246,12 +246,19 @@ pub const UdpSocket = struct {
         const addr = makeSockaddrIn(dest_addr, dest_port);
         if (comptime is_linux) {
             const rc = linux.sendto(self.fd, data.ptr, data.len, 0, @ptrCast(&addr), @sizeOf(@TypeOf(addr)));
-            // Raw syscall returns -errno; libc-mode posix.errno() misses it (only
-            // catches -1), so a failed send returned -errno AS the byte count
-            // (the bogus "ACK sent (-11 bytes)" logs). Check the sign directly:
-            // any error (EAGAIN/ENOBUFS/unreachable) is a clean drop for UDP.
+            // linux.sendto is a RAW syscall returning -errno. std.posix.errno is
+            // WRONG here: under libc it only classifies rv==-1 and reads the C
+            // errno global (which a raw syscall never sets), so -errno slipped
+            // through as a "byte count" — the OOB / "ACK sent (-11 bytes)" bug.
+            // Decode the errno from the negated raw return; map only true
+            // backpressure to WouldBlock and surface the rest as real failures.
             const sgn: isize = @bitCast(rc);
-            if (sgn < 0) return error.WouldBlock;
+            if (sgn < 0) {
+                switch (@as(posix.E, @enumFromInt(@as(u16, @intCast(-sgn))))) {
+                    .AGAIN, .NOBUFS, .INTR => return error.WouldBlock,
+                    else => |e| return posix.unexpectedErrno(e),
+                }
+            }
             return @intCast(rc);
         } else if (comptime is_windows) {
             const n = std.c.sendto(self.fd, data.ptr, data.len, 0, @ptrCast(&addr), @sizeOf(@TypeOf(addr)));
@@ -269,8 +276,13 @@ pub const UdpSocket = struct {
         const addr = makeSockaddrIn6(dest_addr, dest_port);
         if (comptime is_linux) {
             const rc = linux.sendto(self.fd, data.ptr, data.len, 0, @ptrCast(&addr), @sizeOf(@TypeOf(addr)));
-            const sgn: isize = @bitCast(rc); // raw -errno; check sign (see sendTo)
-            if (sgn < 0) return error.WouldBlock;
+            const sgn: isize = @bitCast(rc); // raw -errno; decode the errno (see sendTo)
+            if (sgn < 0) {
+                switch (@as(posix.E, @enumFromInt(@as(u16, @intCast(-sgn))))) {
+                    .AGAIN, .NOBUFS, .INTR => return error.WouldBlock,
+                    else => |e| return posix.unexpectedErrno(e),
+                }
+            }
             return @intCast(rc);
         } else {
             const n = std.c.sendto(self.fd, data.ptr, data.len, 0, @ptrCast(&addr), @sizeOf(@TypeOf(addr)));


### PR DESCRIPTION
## Summary

Fixes a memory-safety bug in the FFI socket layer that caused silent heap
corruption (CPU hangs / network outages on a deployed node) and segfaults, plus
related hardening discovered while tracking it down.

Three commits, smallest-blast-radius first:

### 1. `fix(net/udp)` — the bug (critical)
`recvFrom`/`recvFrom6`/`sendTo`/`sendTo6` call the **raw** linux syscalls
(`std.os.linux.recvfrom`/`sendto`), which return **`-errno` directly**. The
result was checked with `std.posix.errno()` — but with libc linked that only
classifies `rv == -1`, so other `-errno` values (notably **`EAGAIN = -11`**)
passed as `.SUCCESS`, got `@intCast` into a huge `usize`, and were used as a
**slice length / byte count**:

```
buf[0 .. (-11 as usize)]  ->  buf[0 .. 18446744073709551605]   // OOB
```

- ReleaseFast (no bounds checks): silent out-of-bounds memory corruption.
- Debug build bounds-panics:
  `index out of bounds: index 18446744073709551605, len 1500`
  at `udp.zig recvFrom` <- `swim.zig tick` (recv drain) <- `eventLoop`.
- Same `-11` produced bogus `ACK sent (-11 bytes)` logs on the send side.

**Fix:** check the sign of the raw return directly instead of trusting
`posix.errno`, and guard `n > buf.len`. Also surface `POLLERR`/`POLLHUP` in
`pollRead` so a queued socket error is drained rather than spinning a
no-sleep event loop.

### 2. `feat(discovery/swim)` — flood hardening
Token-bucket rate limiter (500 pps, burst 100) on all SWIM control-plane sends
via a single `gossipSend()` chokepoint, so a pathological inbound rate cannot be
amplified into a flood. **Tunnel DATA bypasses this**, so egress throughput is
unaffected. Also removes the unconditional per-packet `std.debug.print` in the
ACK path (a stderr syscall per inbound PING — dominated CPU under load).

### 3. `feat(ffi)` — bind-to-IP + opt-in diagnostics
- `meshguard_init_bind(seed, port, bind_ip)`: bind the UDP socket to a specific
  local IPv4 instead of `INADDR_ANY` (multi-homed / public-IP hosts bind only
  the intended interface). Mirrors the existing `meshguard_init_ipv6` rebind.
- `MESHGUARD_STATS=1`: opt-in once-per-second counter dump in the event loop
  (tick/recv/sent/raw/dropped/punches). No-op unless the env var is set.

## Reproduction & verification (loopback-safe)
Two FFI peers that register each other:
- **Before:** one node crashes (Debug) / CPU ramps to 100% with SWIM counters
  idle (ReleaseFast).
- **After:** both peers survive at ~0.1% CPU (3/3 runs).

Found via a Debug `.so` (`zig build-lib -ODebug`) + `gdb -batch -ex run -ex bt`,
which gave the exact panic above.

## Notes
- Commits 2 and 3 are additive hardening/features — happy to split into separate
  PRs if you'd prefer to land the `udp.zig` fix on its own.
- The send-rate cap value (500 pps) is conservative; tune if needed.
