### PR TITLE
fix: enforce org cert admission and FFI cleanup

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -14,6 +14,7 @@ pub fn build(b: *std.Build) void {
     const is_windows = resolved_os == .windows;
     const is_macos = resolved_os == .macos;
     const is_freebsd = resolved_os == .freebsd;
+    var ffi_tests_step: ?*std.Build.Step = null;
 
     // ─── Crypto backend selection (meshguard#102) ───
     // libsodium is an OPTIONAL accelerator (AVX2 ChaCha20-Poly1305 on Linux),
@@ -75,6 +76,26 @@ pub fn build(b: *std.Build) void {
         }
 
         b.installArtifact(ffi_lib);
+
+        if (!is_android and !is_ios) {
+            const ffi_test_mod = b.createModule(.{
+                .root_source_file = b.path("src/meshguard_ffi.zig"),
+                .target = target,
+                .optimize = optimize,
+                .link_libc = true,
+            });
+            ffi_test_mod.addImport("build_options", build_options_mod);
+
+            const ffi_tests = b.addTest(.{
+                .root_module = ffi_test_mod,
+            });
+            if (use_libsodium) {
+                ffi_test_mod.linkSystemLibrary("sodium", .{});
+            }
+
+            const run_ffi_tests = b.addRunArtifact(ffi_tests);
+            ffi_tests_step = &run_ffi_tests.step;
+        }
     }
 
     // ─── Targets below only build for native (not Android/iOS) ───
@@ -174,5 +195,8 @@ pub fn build(b: *std.Build) void {
         const run_unit_tests = b.addRunArtifact(unit_tests);
         const test_step = b.step("test", "Run unit tests");
         test_step.dependOn(&run_unit_tests.step);
+        if (ffi_tests_step) |step| {
+            test_step.dependOn(step);
+        }
     }
 }

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -12,6 +12,7 @@ const Membership = @import("membership.zig");
 const messages = @import("../protocol/messages.zig");
 const codec = @import("../protocol/codec.zig");
 const keys = @import("../identity/keys.zig");
+const Org = @import("../identity/org.zig");
 const Udp = @import("../net/udp.zig");
 const Holepuncher = @import("../nat/holepunch.zig").Holepuncher;
 const log = std.log.scoped(.swim);
@@ -193,8 +194,50 @@ pub const SwimProtocol = struct {
         self.enforce_trust = true;
     }
 
+    fn nodeIsRevoked(self: *const SwimProtocol, pubkey: [32]u8) bool {
+        for (self.revoked_nodes[0..self.revoked_count]) |revoked| {
+            if (std.mem.eql(u8, &revoked, &pubkey)) return true;
+        }
+        return false;
+    }
+
+    fn certExpiryValid(expires_at: i64) bool {
+        if (expires_at == 0) return true;
+        return @as(i64, @intCast(std.Io.Timestamp.now(zio(), .real).toSeconds())) < expires_at;
+    }
+
+    fn certAuthorizesPeer(self: *const SwimProtocol, pubkey: [32]u8, cert_wire: [messages.ORG_CERT_WIRE_SIZE]u8) bool {
+        const cert = Org.NodeCertificate.deserialize(&cert_wire);
+        if (!std.mem.eql(u8, &cert.node_pubkey, &pubkey)) return false;
+        if (!Org.verifyCertificate(&cert)) return false;
+        if (!cert.isValid()) return false;
+        if (!self.isOrgAuthorizedPeer(cert.org_pubkey)) return false;
+        if (self.nodeIsRevoked(pubkey)) return false;
+        return true;
+    }
+
+    fn recordedCertAuthorizesPeer(self: *const SwimProtocol, pubkey: [32]u8) bool {
+        const peer = self.membership.peers.get(pubkey) orelse return false;
+        const org_pubkey = peer.org_pubkey orelse return false;
+        const expires_at = peer.cert_expires_at orelse return false;
+        if (!self.isOrgAuthorizedPeer(org_pubkey)) return false;
+        if (!certExpiryValid(expires_at)) return false;
+        if (self.nodeIsRevoked(pubkey)) return false;
+        return true;
+    }
+
+    fn recordPeerCertificate(self: *SwimProtocol, pubkey: [32]u8, cert_wire: [messages.ORG_CERT_WIRE_SIZE]u8) void {
+        if (!self.certAuthorizesPeer(pubkey, cert_wire)) return;
+        const cert = Org.NodeCertificate.deserialize(&cert_wire);
+        if (self.membership.peers.getPtr(pubkey)) |peer| {
+            peer.org_pubkey = cert.org_pubkey;
+            peer.org_node_name = cert.node_name;
+            peer.cert_expires_at = cert.expires_at;
+        }
+    }
+
     /// Check if a pubkey is authorized.
-    fn isAuthorizedPeer(self: *const SwimProtocol, pubkey: [32]u8) bool {
+    fn isAuthorizedPeer(self: *const SwimProtocol, pubkey: [32]u8, presented_cert: ?[messages.ORG_CERT_WIRE_SIZE]u8) bool {
         if (!self.enforce_trust) return true;
         // Always allow our own pubkey
         if (std.mem.eql(u8, &pubkey, &self.our_pubkey)) return true;
@@ -208,6 +251,12 @@ pub const SwimProtocol = struct {
         for (self.revoked_nodes[0..self.revoked_count]) |revoked| {
             if (std.mem.eql(u8, &revoked, &pubkey)) return false;
         }
+        // Check previously admitted org certificate
+        if (self.recordedCertAuthorizesPeer(pubkey)) return true;
+        // Check presented org certificate
+        if (presented_cert) |cert_wire| {
+            if (self.certAuthorizesPeer(pubkey, cert_wire)) return true;
+        }
         // Check if vouched by a trusted org
         for (0..self.vouched_count) |i| {
             if (std.mem.eql(u8, &self.vouched_node_keys[i], &pubkey)) {
@@ -215,10 +264,6 @@ pub const SwimProtocol = struct {
                 if (self.isOrgAuthorizedPeer(self.vouched_org_keys[i])) return true;
             }
         }
-        // If we have trusted orgs, allow unknown peers through to handshake
-        // where their org cert will be verified. Without this, org cert members
-        // get dropped at the SWIM layer before handshake can happen.
-        if (self.trusted_org_count > 0) return true;
         return false;
     }
 
@@ -273,6 +318,8 @@ pub const SwimProtocol = struct {
             .sender_pubkey = self.our_pubkey,
             .seq = self.seq +% 1,
             .gossip = &leave_gossip,
+            .org_cert = self.our_org_cert orelse std.mem.zeroes([messages.ORG_CERT_WIRE_SIZE]u8),
+            .has_org_cert = self.our_org_cert != null,
         };
 
         var buf: [1500]u8 = undefined;
@@ -503,7 +550,16 @@ pub const SwimProtocol = struct {
             .org_cert_revoke => |rev| rev.org_pubkey,
             .org_trust_vouch => |v| v.org_pubkey,
         };
-        if (!self.isAuthorizedPeer(sender_pubkey)) return;
+        const presented_cert: ?[messages.ORG_CERT_WIRE_SIZE]u8 = switch (decoded) {
+            .ping => |p| if (p.has_org_cert) p.org_cert else null,
+            .ack => |a| if (a.has_org_cert) a.org_cert else null,
+            else => null,
+        };
+        const org_control_message = switch (decoded) {
+            .org_alias_announce, .org_cert_revoke, .org_trust_vouch => true,
+            else => false,
+        };
+        if (!org_control_message and !self.isAuthorizedPeer(sender_pubkey, presented_cert)) return;
 
         switch (decoded) {
             .ping => |p| self.handlePing(&p, sender_endpoint),
@@ -684,6 +740,9 @@ pub const SwimProtocol = struct {
         // Register sender FIRST so gossip callbacks see the real network address
         if (!std.mem.eql(u8, &ping.sender_pubkey, &([_]u8{0} ** 32))) {
             self.registerOrUpdatePeerEndpoint(ping.sender_pubkey, sender_endpoint);
+            if (ping.has_org_cert) {
+                self.recordPeerCertificate(ping.sender_pubkey, ping.org_cert);
+            }
         }
 
         // Process piggybacked gossip (onPeerJoin may fire here)
@@ -697,6 +756,8 @@ pub const SwimProtocol = struct {
             .sender_pubkey = self.our_pubkey,
             .seq = ping.seq,
             .gossip = gossip,
+            .org_cert = self.our_org_cert orelse std.mem.zeroes([messages.ORG_CERT_WIRE_SIZE]u8),
+            .has_org_cert = self.our_org_cert != null,
         };
 
         var buf: [1500]u8 = undefined;
@@ -713,6 +774,9 @@ pub const SwimProtocol = struct {
         // Register sender FIRST so gossip callbacks see the real network address
         if (!std.mem.eql(u8, &ack.sender_pubkey, &([_]u8{0} ** 32))) {
             self.registerOrUpdatePeerEndpoint(ack.sender_pubkey, sender_endpoint);
+            if (ack.has_org_cert) {
+                self.recordPeerCertificate(ack.sender_pubkey, ack.org_cert);
+            }
         }
 
         // Process piggybacked gossip (onPeerJoin may fire here)
@@ -951,6 +1015,8 @@ pub const SwimProtocol = struct {
             .sender_pubkey = self.our_pubkey,
             .seq = self.seq,
             .gossip = gossip,
+            .org_cert = self.our_org_cert orelse std.mem.zeroes([messages.ORG_CERT_WIRE_SIZE]u8),
+            .has_org_cert = self.our_org_cert != null,
         };
 
         var buf: [1500]u8 = undefined;
@@ -1221,6 +1287,59 @@ fn aliveTestPeer(pk: [32]u8) Membership.Peer {
         .last_rtt_ns = null,
         .handshake_complete = false,
     };
+}
+
+test "trusted org does not admit arbitrary peers without a cert" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+    var socket = Udp.UdpSocket.bind(0) catch return;
+    defer socket.close();
+
+    var swim = SwimProtocol.init(&membership, socket, .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, null);
+    swim.enableTrust();
+    swim.addTrustedOrg([_]u8{0xA0} ** 32);
+
+    try std.testing.expect(!swim.isAuthorizedPeer([_]u8{0x55} ** 32, null));
+}
+
+test "valid trusted org cert admits and records peer until revoked" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+    var socket = Udp.UdpSocket.bind(0) catch return;
+    defer socket.close();
+
+    var swim = SwimProtocol.init(&membership, socket, .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, null);
+    swim.enableTrust();
+
+    const org_kp = Org.generateOrgKeyPair();
+    const org_pubkey = org_kp.public_key.toBytes();
+    swim.addTrustedOrg(org_pubkey);
+
+    const node_kp = keys.generate();
+    const node_pubkey = node_kp.public_key.toBytes();
+    var cert = try Org.issueCertificate(org_kp, node_pubkey, "node-1", 0);
+    var cert_wire: [messages.ORG_CERT_WIRE_SIZE]u8 = undefined;
+    cert.serialize(&cert_wire);
+
+    try std.testing.expect(swim.isAuthorizedPeer(node_pubkey, cert_wire));
+    try std.testing.expect(!swim.isAuthorizedPeer([_]u8{0x66} ** 32, cert_wire));
+
+    try membership.upsert(aliveTestPeer(node_pubkey));
+    swim.recordPeerCertificate(node_pubkey, cert_wire);
+
+    const recorded = membership.peers.get(node_pubkey).?;
+    try std.testing.expect(recorded.org_pubkey != null);
+    try std.testing.expectEqualSlices(u8, &org_pubkey, &recorded.org_pubkey.?);
+    try std.testing.expectEqualSlices(u8, &cert.node_name, &recorded.org_node_name);
+    try std.testing.expectEqual(@as(?i64, 0), recorded.cert_expires_at);
+    try std.testing.expect(swim.isAuthorizedPeer(node_pubkey, null));
+
+    swim.revoked_nodes[0] = node_pubkey;
+    swim.revoked_count = 1;
+    try std.testing.expect(!swim.isAuthorizedPeer(node_pubkey, null));
+    try std.testing.expect(!swim.isAuthorizedPeer(node_pubkey, cert_wire));
 }
 
 test "org revoke requires a valid trusted-org signature (C2 regression)" {

--- a/src/meshguard_ffi.zig
+++ b/src/meshguard_ffi.zig
@@ -125,6 +125,54 @@ pub const MeshguardContext = struct {
     alloc: std.mem.Allocator,
 };
 
+fn initContextStorage(allocator: std.mem.Allocator) MeshguardContext {
+    return .{
+        .ed25519_seed = undefined,
+        .ed25519_public = undefined,
+        .x25519_private = undefined,
+        .x25519_public = undefined,
+        .membership = Membership.MembershipTable.init(allocator, 15000),
+        .swim = null,
+        .socket = null,
+        .lan_discovery = null,
+        .event_loop_thread = null,
+        .running = std.atomic.Value(bool).init(false),
+        .suspended = std.atomic.Value(bool).init(false),
+        .on_message_cb = null,
+        .on_peer_event_cb = null,
+        .on_undeliverable_cb = null,
+        .inbox = std.mem.zeroes([64]AppMessage),
+        .inbox_write = std.atomic.Value(u32).init(0),
+        .inbox_read = std.atomic.Value(u32).init(0),
+        .wg_device = null,
+        .wg_lock = .init,
+        .tunnel_inbox = std.mem.zeroes([256]TunnelMessage),
+        .tunnel_inbox_write = std.atomic.Value(u32).init(0),
+        .tunnel_inbox_read = std.atomic.Value(u32).init(0),
+        .alloc = allocator,
+    };
+}
+
+fn closeContextSocket(ctx: *MeshguardContext) void {
+    if (ctx.socket) |*s| {
+        s.close();
+    }
+    ctx.socket = null;
+}
+
+fn destroyContext(ctx: *MeshguardContext) void {
+    meshguard_leave(ctx);
+    closeContextSocket(ctx);
+    ctx.membership.deinit();
+    ctx.alloc.destroy(ctx);
+}
+
+fn tunnelFramePayloadLen(frame_len: usize, encoded_payload_len: u16) ?usize {
+    const payload_len: usize = @intCast(encoded_payload_len);
+    if (payload_len + 4 > frame_len) return null;
+    return payload_len;
+}
+
 /// Application-level encrypted message in the inbox.
 const AppMessage = struct {
     sender_pubkey: [32]u8,
@@ -162,31 +210,7 @@ export fn meshguard_init(
     };
 
     const ctx = allocator.create(MeshguardContext) catch return null;
-    ctx.* = .{
-        .ed25519_seed = undefined,
-        .ed25519_public = undefined,
-        .x25519_private = undefined,
-        .x25519_public = undefined,
-        .membership = Membership.MembershipTable.init(allocator, 15000),
-        .swim = null,
-        .socket = null,
-        .lan_discovery = null,
-        .event_loop_thread = null,
-        .running = std.atomic.Value(bool).init(false),
-        .suspended = std.atomic.Value(bool).init(false),
-        .on_message_cb = null,
-        .on_peer_event_cb = null,
-        .on_undeliverable_cb = null,
-        .inbox = std.mem.zeroes([64]AppMessage),
-        .inbox_write = std.atomic.Value(u32).init(0),
-        .inbox_read = std.atomic.Value(u32).init(0),
-        .wg_device = null, // Initialized after key derivation
-        .wg_lock = .init,
-        .tunnel_inbox = std.mem.zeroes([256]TunnelMessage),
-        .tunnel_inbox_write = std.atomic.Value(u32).init(0),
-        .tunnel_inbox_read = std.atomic.Value(u32).init(0),
-        .alloc = allocator,
-    };
+    ctx.* = initContextStorage(allocator);
 
     // Identity: use provided seed or generate.
     var identity_seed_bytes: [32]u8 = undefined;
@@ -197,7 +221,7 @@ export fn meshguard_init(
     }
 
     const kp = Ed25519.KeyPair.generateDeterministic(identity_seed_bytes) catch {
-        allocator.destroy(ctx);
+        destroyContext(ctx);
         return null;
     };
     const pub_bytes = kp.public_key.toBytes();
@@ -212,7 +236,7 @@ export fn meshguard_init(
     x_priv[31] |= 64;
     ctx.x25519_private = x_priv;
     ctx.x25519_public = X25519.recoverPublicKey(x_priv) catch {
-        allocator.destroy(ctx);
+        destroyContext(ctx);
         return null;
     };
 
@@ -221,7 +245,7 @@ export fn meshguard_init(
 
     // Bind UDP socket — use ephemeral port (0) on mobile for reliability
     ctx.socket = Udp.UdpSocket.bind(listen_port) catch {
-        allocator.destroy(ctx);
+        destroyContext(ctx);
         return null;
     };
 
@@ -234,9 +258,9 @@ export fn meshguard_init_ipv6(
     listen_port: u16,
 ) ?*MeshguardContext {
     const ctx = meshguard_init(identity_seed, listen_port) orelse return null;
-    if (ctx.socket) |*s| s.close();
+    closeContextSocket(ctx);
     ctx.socket = Udp.UdpSocket.bindAddr6(.{0} ** 16, listen_port) catch {
-        ctx.alloc.destroy(ctx);
+        destroyContext(ctx);
         return null;
     };
     return ctx;
@@ -256,11 +280,11 @@ export fn meshguard_init_bind(
     // allocation so a bad pointer fails cleanly instead of crashing in @memcpy.
     const ip_ptr = bind_ip orelse return null;
     const ctx = meshguard_init(identity_seed, listen_port) orelse return null;
-    if (ctx.socket) |*s| s.close();
+    closeContextSocket(ctx);
     var addr: [4]u8 = undefined;
     @memcpy(&addr, ip_ptr[0..4]);
     ctx.socket = Udp.UdpSocket.bindAddr(addr, listen_port) catch {
-        ctx.alloc.destroy(ctx);
+        destroyContext(ctx);
         return null;
     };
     return ctx;
@@ -269,13 +293,7 @@ export fn meshguard_init_bind(
 /// Destroy a meshguard instance, stopping all networking.
 export fn meshguard_destroy(ctx: ?*MeshguardContext) void {
     const c = ctx orelse return;
-    meshguard_leave(c);
-
-    if (c.socket) |*s| {
-        s.close();
-    }
-
-    c.alloc.destroy(c);
+    destroyContext(c);
 }
 
 /// Get our Ed25519 public key (32 bytes).
@@ -1025,8 +1043,8 @@ fn eventLoop(ctx: *MeshguardContext) void {
                 if (now - last_stats_ns >= 1_000_000_000) {
                     last_stats_ns = now;
                     std.debug.print("[stats] tick/s={d} recv/s={d} sent/s={d} raw/s={d} dropped/s={d} punches={d}\n", .{
-                        swim.tick_count -% s_tick,    swim.pkts_recv -% s_recv,
-                        swim.pkts_sent -% s_sent,     swim.raw_recv -% s_raw,
+                        swim.tick_count -% s_tick,              swim.pkts_recv -% s_recv,
+                        swim.pkts_sent -% s_sent,               swim.raw_recv -% s_raw,
                         swim.sends_dropped_ratelimit -% s_drop, swim.holepuncher.activeCount(),
                     });
                     s_tick = swim.tick_count;
@@ -1274,8 +1292,8 @@ fn handleWgPacket(ctx: *MeshguardContext, data: []const u8, sender_addr: [4]u8, 
             if (result.len < 4) return;
             if (plaintext[0] != 0 or plaintext[1] != 0) return; // Not our framing
             const payload_len = std.mem.readInt(u16, plaintext[2..4], .little);
-            if (payload_len + 4 > result.len) return; // Corrupt frame
-            enqueueTunnelMessage(ctx, sender_identity, plaintext[4..][0..payload_len]);
+            const payload_end = tunnelFramePayloadLen(result.len, payload_len) orelse return; // Corrupt frame
+            enqueueTunnelMessage(ctx, sender_identity, plaintext[4..][0..payload_end]);
         },
         else => {}, // Cookie (Type 3) not implemented yet
     }
@@ -1522,4 +1540,35 @@ export fn meshguard_tunnel_close(
             std.debug.print("  \xf0\x9f\x94\x91 Tunnel closed with {x:0>2}{x:0>2}...\n", .{ target_key[0], target_key[1] });
         }
     }
+}
+
+test "destroyContext releases FFI-owned membership allocations" {
+    const allocator = std.testing.allocator;
+    const ctx = try allocator.create(MeshguardContext);
+    ctx.* = initContextStorage(allocator);
+
+    const peer_name = try allocator.dupe(u8, "ffi-peer");
+    try ctx.membership.upsert(.{
+        .pubkey = [_]u8{0x42} ** 32,
+        .name = peer_name,
+        .state = .alive,
+        .gossip_endpoint = null,
+        .wg_pubkey = null,
+        .mesh_ip = .{ 10, 99, 0, 42 },
+        .wg_port = 51830,
+        .lamport = 1,
+        .last_seen_ns = 0,
+        .suspected_at_ns = null,
+        .last_rtt_ns = null,
+        .handshake_complete = false,
+    });
+
+    destroyContext(ctx);
+}
+
+test "tunnel frame payload length guard widens before adding header" {
+    try std.testing.expectEqual(@as(?usize, 0), tunnelFramePayloadLen(4, 0));
+    try std.testing.expectEqual(@as(?usize, 1496), tunnelFramePayloadLen(1500, 1496));
+    try std.testing.expectEqual(@as(?usize, null), tunnelFramePayloadLen(4, 65535));
+    try std.testing.expectEqual(@as(?usize, null), tunnelFramePayloadLen(1500, 65535));
 }

--- a/src/protocol/codec.zig
+++ b/src/protocol/codec.zig
@@ -13,12 +13,14 @@ const messages = @import("messages.zig");
 
 const ENDPOINT_SIZE = 1 + 1 + 16 + 2;
 const GOSSIP_ENTRY_SIZE = 32 + 1 + 8 + ENDPOINT_SIZE + 1 + 32 + ENDPOINT_SIZE + 1; // 115 bytes
+const ORG_CERT_EXTENSION_SIZE = 1 + messages.ORG_CERT_WIRE_SIZE;
 
 // ─── Encoding ───
 
 /// Encode a Ping message into a buffer. Returns bytes written.
 pub fn encodePing(buf: []u8, ping: messages.Ping) !usize {
-    const required = 1 + 32 + 8 + 1 + ping.gossip.len * GOSSIP_ENTRY_SIZE;
+    const required = 1 + 32 + 8 + 1 + ping.gossip.len * GOSSIP_ENTRY_SIZE +
+        if (ping.has_org_cert) ORG_CERT_EXTENSION_SIZE else 0;
     if (buf.len < required) return error.BufferTooShort;
 
     var pos: usize = 0;
@@ -44,12 +46,20 @@ pub fn encodePing(buf: []u8, ping: messages.Ping) !usize {
         pos += try encodeGossipEntry(buf[pos..], entry);
     }
 
+    if (ping.has_org_cert) {
+        buf[pos] = 1;
+        pos += 1;
+        @memcpy(buf[pos..][0..messages.ORG_CERT_WIRE_SIZE], &ping.org_cert);
+        pos += messages.ORG_CERT_WIRE_SIZE;
+    }
+
     return pos;
 }
 
 /// Encode an Ack message into a buffer. Returns bytes written.
 pub fn encodeAck(buf: []u8, ack: messages.Ack) !usize {
-    const required = 1 + 32 + 8 + 1 + ack.gossip.len * GOSSIP_ENTRY_SIZE;
+    const required = 1 + 32 + 8 + 1 + ack.gossip.len * GOSSIP_ENTRY_SIZE +
+        if (ack.has_org_cert) ORG_CERT_EXTENSION_SIZE else 0;
     if (buf.len < required) return error.BufferTooShort;
 
     var pos: usize = 0;
@@ -69,6 +79,13 @@ pub fn encodeAck(buf: []u8, ack: messages.Ack) !usize {
 
     for (ack.gossip[0..gossip_count]) |entry| {
         pos += try encodeGossipEntry(buf[pos..], entry);
+    }
+
+    if (ack.has_org_cert) {
+        buf[pos] = 1;
+        pos += 1;
+        @memcpy(buf[pos..][0..messages.ORG_CERT_WIRE_SIZE], &ack.org_cert);
+        pos += messages.ORG_CERT_WIRE_SIZE;
     }
 
     return pos;
@@ -331,6 +348,8 @@ pub const DecodedPing = struct {
     seq: u64,
     gossip_buf: [8]messages.GossipEntry = undefined,
     gossip_count: u8 = 0,
+    org_cert: [messages.ORG_CERT_WIRE_SIZE]u8 = std.mem.zeroes([messages.ORG_CERT_WIRE_SIZE]u8),
+    has_org_cert: bool = false,
 
     pub fn gossip(self: *const DecodedPing) []const messages.GossipEntry {
         return self.gossip_buf[0..self.gossip_count];
@@ -343,6 +362,8 @@ pub const DecodedAck = struct {
     seq: u64,
     gossip_buf: [8]messages.GossipEntry = undefined,
     gossip_count: u8 = 0,
+    org_cert: [messages.ORG_CERT_WIRE_SIZE]u8 = std.mem.zeroes([messages.ORG_CERT_WIRE_SIZE]u8),
+    has_org_cert: bool = false,
 
     pub fn gossip(self: *const DecodedAck) []const messages.GossipEntry {
         return self.gossip_buf[0..self.gossip_count];
@@ -381,15 +402,19 @@ fn decodePing(data: []const u8) DecodeError!DecodedPing {
     @memcpy(&result.sender_pubkey, data[0..32]);
     result.seq = std.mem.readInt(u64, data[32..40], .little);
 
-    const gossip_count = @min(data[40], 8);
-    result.gossip_count = gossip_count;
+    const advertised_gossip_count = @min(data[40], 8);
 
     var pos: usize = 41;
-    for (0..gossip_count) |i| {
+    var parsed_gossip_count: u8 = 0;
+    for (0..advertised_gossip_count) |i| {
         if (pos + GOSSIP_ENTRY_SIZE > data.len) break;
         result.gossip_buf[i] = decodeGossipEntry(data[pos..]) catch break;
         pos += GOSSIP_ENTRY_SIZE;
+        parsed_gossip_count += 1;
     }
+    result.gossip_count = parsed_gossip_count;
+
+    try decodeOrgCertExtension(data, pos, &result.org_cert, &result.has_org_cert);
 
     return result;
 }
@@ -405,17 +430,34 @@ fn decodeAck(data: []const u8) DecodeError!DecodedAck {
     @memcpy(&result.sender_pubkey, data[0..32]);
     result.seq = std.mem.readInt(u64, data[32..40], .little);
 
-    const gossip_count = @min(data[40], 8);
-    result.gossip_count = gossip_count;
+    const advertised_gossip_count = @min(data[40], 8);
 
     var pos: usize = 41;
-    for (0..gossip_count) |i| {
+    var parsed_gossip_count: u8 = 0;
+    for (0..advertised_gossip_count) |i| {
         if (pos + GOSSIP_ENTRY_SIZE > data.len) break;
         result.gossip_buf[i] = decodeGossipEntry(data[pos..]) catch break;
         pos += GOSSIP_ENTRY_SIZE;
+        parsed_gossip_count += 1;
     }
+    result.gossip_count = parsed_gossip_count;
+
+    try decodeOrgCertExtension(data, pos, &result.org_cert, &result.has_org_cert);
 
     return result;
+}
+
+fn decodeOrgCertExtension(
+    data: []const u8,
+    pos: usize,
+    cert: *[messages.ORG_CERT_WIRE_SIZE]u8,
+    has_cert: *bool,
+) DecodeError!void {
+    if (pos >= data.len) return;
+    if (data[pos] != 1) return;
+    if (pos + ORG_CERT_EXTENSION_SIZE > data.len) return error.BufferTooShort;
+    @memcpy(cert, data[pos + 1 ..][0..messages.ORG_CERT_WIRE_SIZE]);
+    has_cert.* = true;
 }
 
 fn decodePingReq(data: []const u8) DecodeError!messages.PingReq {
@@ -580,6 +622,54 @@ test "ack roundtrip" {
     switch (decoded) {
         .ack => |a| {
             try std.testing.expectEqual(a.seq, 99);
+        },
+        else => return error.InvalidMessageType,
+    }
+}
+
+test "ping optional org cert extension roundtrip" {
+    const pubkey = [_]u8{0x42} ** 32;
+    const cert = [_]u8{0xC7} ** messages.ORG_CERT_WIRE_SIZE;
+    const ping = messages.Ping{
+        .sender_pubkey = pubkey,
+        .seq = 12345,
+        .gossip = &.{},
+        .org_cert = cert,
+        .has_org_cert = true,
+    };
+
+    var buf: [512]u8 = undefined;
+    const written = try encodePing(&buf, ping);
+
+    const decoded = try decode(buf[0..written]);
+    switch (decoded) {
+        .ping => |p| {
+            try std.testing.expect(p.has_org_cert);
+            try std.testing.expectEqualSlices(u8, &cert, &p.org_cert);
+        },
+        else => return error.InvalidMessageType,
+    }
+}
+
+test "ack optional org cert extension roundtrip" {
+    const pubkey = [_]u8{0xAA} ** 32;
+    const cert = [_]u8{0xAC} ** messages.ORG_CERT_WIRE_SIZE;
+    const ack = messages.Ack{
+        .sender_pubkey = pubkey,
+        .seq = 99,
+        .gossip = &.{},
+        .org_cert = cert,
+        .has_org_cert = true,
+    };
+
+    var buf: [512]u8 = undefined;
+    const written = try encodeAck(&buf, ack);
+
+    const decoded = try decode(buf[0..written]);
+    switch (decoded) {
+        .ack => |a| {
+            try std.testing.expect(a.has_org_cert);
+            try std.testing.expectEqualSlices(u8, &cert, &a.org_cert);
         },
         else => return error.InvalidMessageType,
     }

--- a/src/protocol/messages.zig
+++ b/src/protocol/messages.zig
@@ -5,6 +5,8 @@
 
 const std = @import("std");
 
+pub const ORG_CERT_WIRE_SIZE: usize = 186;
+
 /// Message type tag — first byte of every wire message.
 pub const MessageType = enum(u8) {
     // ─── SWIM protocol ───
@@ -48,6 +50,10 @@ pub const Ping = struct {
     seq: u64,
     /// Piggybacked gossip updates
     gossip: []const GossipEntry,
+    /// Org certificate extension appended after gossip, if present.
+    org_cert: [ORG_CERT_WIRE_SIZE]u8 = std.mem.zeroes([ORG_CERT_WIRE_SIZE]u8),
+    /// Whether org_cert contains a valid certificate.
+    has_org_cert: bool = false,
 };
 
 /// SWIM Ping-Req: ask another node to probe a target.
@@ -62,6 +68,10 @@ pub const Ack = struct {
     sender_pubkey: [32]u8,
     seq: u64,
     gossip: []const GossipEntry,
+    /// Org certificate extension appended after gossip, if present.
+    org_cert: [ORG_CERT_WIRE_SIZE]u8 = std.mem.zeroes([ORG_CERT_WIRE_SIZE]u8),
+    /// Whether org_cert contains a valid certificate.
+    has_org_cert: bool = false,
 };
 
 /// Handshake initiation: sent when two nodes first discover each other.
@@ -73,8 +83,8 @@ pub const HandshakeInit = struct {
     mesh_ip: [4]u8, // sender's deterministic mesh IP
     wg_port: u16, // sender's WireGuard listen port
     gossip_port: u16, // sender's gossip listen port
-    /// Org certificate (186 bytes), zeroes if none
-    org_cert: [186]u8 = std.mem.zeroes([186]u8),
+    /// Org certificate, zeroes if none
+    org_cert: [ORG_CERT_WIRE_SIZE]u8 = std.mem.zeroes([ORG_CERT_WIRE_SIZE]u8),
     /// Whether org_cert contains a valid certificate
     has_org_cert: bool = false,
 };
@@ -89,8 +99,8 @@ pub const HandshakeResp = struct {
     mesh_ip: [4]u8,
     wg_port: u16,
     gossip_port: u16,
-    /// Org certificate (186 bytes), zeroes if none
-    org_cert: [186]u8 = std.mem.zeroes([186]u8),
+    /// Org certificate, zeroes if none
+    org_cert: [ORG_CERT_WIRE_SIZE]u8 = std.mem.zeroes([ORG_CERT_WIRE_SIZE]u8),
     /// Whether org_cert contains a valid certificate
     has_org_cert: bool = false,
 };
@@ -151,8 +161,8 @@ pub const Endpoint = struct {
     pub fn format(self: Endpoint, buf: []u8) []const u8 {
         const result = if (self.addr6) |a6|
             std.fmt.bufPrint(buf, "[{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}]:{d}", .{
-                a6[0], a6[1], a6[2], a6[3], a6[4], a6[5], a6[6], a6[7],
-                a6[8], a6[9], a6[10], a6[11], a6[12], a6[13], a6[14], a6[15],
+                a6[0],     a6[1], a6[2],  a6[3],  a6[4],  a6[5],  a6[6],  a6[7],
+                a6[8],     a6[9], a6[10], a6[11], a6[12], a6[13], a6[14], a6[15],
                 self.port,
             })
         else


### PR DESCRIPTION
## Summary

Fixes the three currently open implementation issues in `igorls/meshguard`:

- Fixes #106 by widening the FFI tunnel frame payload length before adding the 4-byte framing header.
- Fixes #107 by routing FFI init failure paths and normal destroy through shared context cleanup that closes sockets, deinits `MembershipTable`, and destroys the context.
- Fixes #108 by wiring org certificate admission into SWIM Ping/Ack, removing the trusted-org allow-all shortcut, recording admitted cert metadata, and honoring revocation for certificate-based admission.

## Root Cause

The FFI tunnel guard performed arithmetic in the narrow `u16` payload type, allowing ReleaseFast wraparound before the later payload-size drop. FFI context failure paths destroyed the context without deiniting owned membership allocations. Org trust had certificate primitives and storage, but the SWIM admission path never transmitted or verified a presented node cert and instead admitted unknown peers whenever any org was trusted.

## Validation

- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- `zig build test -Doptimize=ReleaseFast`
- `zig build -Dtarget=x86_64-linux-gnu -Dno-sodium=true`
- `git diff --check` (only Windows CRLF warnings)
