### PR TITLE
fix(swim): heal WG tunnel after a peer restarts (incarnation-based rejoin)

### DIFF
--- a/src/discovery/membership.zig
+++ b/src/discovery/membership.zig
@@ -53,6 +53,10 @@ pub const Peer = struct {
     last_rtt_ns: ?u64,
     /// Whether handshake has been completed
     handshake_complete: bool,
+    /// Peer's advertised incarnation (startup epoch). When a ping/ack arrives
+    /// with a higher incarnation than this, the peer has restarted and must be
+    /// re-integrated. 0 = not yet known.
+    incarnation: u64 = 0,
     /// STUN-discovered public endpoint (NAT traversal)
     public_endpoint: ?messages.Endpoint = null,
     /// NAT type classification

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -26,6 +26,15 @@ fn nowNs() i128 {
     return @intCast(std.Io.Timestamp.now(zio(), .awake).toNanoseconds());
 }
 
+/// Per-process incarnation: wall-clock seconds captured at startup. Increases
+/// on every restart, so a peer that already knows us can tell we RESTARTED
+/// (incarnation higher than it has stored) and re-integrate us — this is what
+/// heals a WireGuard tunnel after one side restarts (the survivor otherwise
+/// treats the rejoiner as already-known and never re-advertises itself).
+fn incarnationNow() u64 {
+    return @intCast(std.Io.Timestamp.now(zio(), .real).toSeconds());
+}
+
 pub const SwimConfig = struct {
     gossip_port: u16 = 51821,
     gossip_interval_ms: u32 = 5000, // 5s — reasonable for WAN
@@ -93,6 +102,9 @@ pub const SwimProtocol = struct {
     our_mesh_ip: [4]u8,
     our_mesh_ip6: [16]u8,
     our_wg_port: u16,
+    /// Our startup incarnation (see incarnationNow). Advertised in every
+    /// ping/ack so peers can detect our restarts.
+    our_incarnation: u64,
     socket: Udp.UdpSocket,
     handler: ?EventHandler,
     running: std.atomic.Value(bool),
@@ -191,6 +203,7 @@ pub const SwimProtocol = struct {
             .our_mesh_ip = our_mesh_ip,
             .our_mesh_ip6 = @import("../wireguard/ip.zig").deriveIpv6FromPubkeyBytes(our_pubkey),
             .our_wg_port = our_wg_port,
+            .our_incarnation = incarnationNow(),
             .socket = socket,
             .handler = handler,
             .running = std.atomic.Value(bool).init(true),
@@ -339,6 +352,7 @@ pub const SwimProtocol = struct {
         const ping = messages.Ping{
             .sender_pubkey = self.our_pubkey,
             .seq = self.seq +% 1,
+            .incarnation = self.our_incarnation,
             .gossip = &leave_gossip,
             .org_cert = self.our_org_cert orelse std.mem.zeroes([messages.ORG_CERT_WIRE_SIZE]u8),
             .has_org_cert = self.our_org_cert != null,
@@ -772,6 +786,8 @@ pub const SwimProtocol = struct {
                 self.recordPeerCertificate(ping.sender_pubkey, ping.org_cert);
             }
             self.removeCandidatePeer(ping.sender_pubkey);
+            // Authenticated contact: detect + heal a peer restart.
+            self.handleSenderIncarnation(ping.sender_pubkey, ping.incarnation);
         }
 
         // Process piggybacked gossip (onPeerJoin may fire here)
@@ -784,6 +800,7 @@ pub const SwimProtocol = struct {
         const ack = messages.Ack{
             .sender_pubkey = self.our_pubkey,
             .seq = ping.seq,
+            .incarnation = self.our_incarnation,
             .gossip = gossip,
             .org_cert = self.our_org_cert orelse std.mem.zeroes([messages.ORG_CERT_WIRE_SIZE]u8),
             .has_org_cert = self.our_org_cert != null,
@@ -807,6 +824,8 @@ pub const SwimProtocol = struct {
                 self.recordPeerCertificate(ack.sender_pubkey, ack.org_cert);
             }
             self.removeCandidatePeer(ack.sender_pubkey);
+            // Authenticated contact: detect + heal a peer restart.
+            self.handleSenderIncarnation(ack.sender_pubkey, ack.incarnation);
         }
 
         // Process piggybacked gossip (onPeerJoin may fire here)
@@ -1052,6 +1071,7 @@ pub const SwimProtocol = struct {
         const ping = messages.Ping{
             .sender_pubkey = self.our_pubkey,
             .seq = self.seq,
+            .incarnation = self.our_incarnation,
             .gossip = gossip,
             .org_cert = self.our_org_cert orelse std.mem.zeroes([messages.ORG_CERT_WIRE_SIZE]u8),
             .has_org_cert = self.our_org_cert != null,
@@ -1274,6 +1294,65 @@ pub const SwimProtocol = struct {
                 .remaining = self.config.max_gossip_broadcasts,
             };
             self.gossip_count += 1;
+        }
+    }
+
+    /// Enqueue a fresh advertisement of ourselves (identity + wg_pubkey +
+    /// endpoint). Used both for the initial join and to re-advertise after a
+    /// peer restarts, so the rejoiner re-learns us and can complete the WG
+    /// handshake. Bounded and queued (max_gossip_broadcasts), unlike a
+    /// per-packet injection.
+    fn enqueueSelfGossip(self: *SwimProtocol) void {
+        self.enqueueGossip(.{
+            .subject_pubkey = self.our_pubkey,
+            .event = .alive,
+            .lamport = self.membership.lamport,
+            .endpoint = self.our_public_endpoint orelse messages.Endpoint.initV6(self.our_mesh_ip6, self.config.gossip_port),
+            .wg_pubkey = self.our_wg_pubkey,
+            .public_endpoint = self.our_public_endpoint,
+            .nat_type = self.our_nat_type,
+        });
+    }
+
+    /// Detect and heal a peer restart from an AUTHENTICATED ping/ack. If the
+    /// sender's incarnation exceeds what we have stored, it restarted with the
+    /// same identity: the survivor otherwise keeps it as already-known and never
+    /// re-advertises itself, so the rejoiner (which lost all state) never
+    /// re-learns us and the WG tunnel never re-forms. We re-advertise ourselves
+    /// (rejoiner re-learns us -> re-initiates the handshake, which our WG
+    /// responder services with a fresh session) and drop our stale
+    /// handshake_complete flag so we also re-initiate.
+    ///
+    /// SECURITY: only ever called from the ping/ack handlers, which have already
+    /// passed isAuthorizedPeer, and it acts only on the AUTHENTICATED sender's
+    /// own entry — never from gossip. A forged gossip "rejoin" for a third party
+    /// cannot reach this path, so it cannot rebind or tear down a trusted peer's
+    /// session.
+    fn handleSenderIncarnation(self: *SwimProtocol, sender_pubkey: [32]u8, incarnation: u64) void {
+        if (incarnation == 0) return; // peer predates incarnation support
+        if (std.mem.eql(u8, &sender_pubkey, &self.our_pubkey)) return;
+        const peer = self.membership.peers.getPtr(sender_pubkey) orelse return;
+        if (peer.incarnation == 0) {
+            // First incarnation seen for this peer — record it (not a restart).
+            peer.incarnation = incarnation;
+            return;
+        }
+        if (incarnation <= peer.incarnation) return; // steady state
+        // Higher incarnation => the peer RESTARTED. Re-integrate it.
+        peer.incarnation = incarnation;
+        peer.handshake_complete = false;
+        // Re-advertise ourselves so the rejoiner (which lost all state)
+        // re-learns our identity + wg_pubkey.
+        self.enqueueSelfGossip();
+        // Rebuild the WG session for the peer: onPeerDead removes the stale peer
+        // (addPeerWithEndpoint would otherwise reuse the old completed handshake
+        // slot and the re-init runs on stale state), then onPeerJoin re-adds it
+        // fresh and the deterministic initiator re-sends a handshake initiation.
+        // The periodic retransmit in tick() covers the init/ack race where our
+        // init reaches the rejoiner before it has re-learned us.
+        if (self.handler) |h| {
+            h.onPeerDead(h.ctx, sender_pubkey);
+            h.onPeerJoin(h.ctx, peer);
         }
     }
 

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -26,13 +26,19 @@ fn nowNs() i128 {
     return @intCast(std.Io.Timestamp.now(zio(), .awake).toNanoseconds());
 }
 
-/// Per-process incarnation: wall-clock seconds captured at startup. Increases
-/// on every restart, so a peer that already knows us can tell we RESTARTED
-/// (incarnation higher than it has stored) and re-integrate us — this is what
+/// Per-process incarnation: wall-clock NANOSECONDS captured at startup.
+/// Increases on every restart, so a peer that already knows us can tell we
+/// RESTARTED (incarnation higher than it has stored) and re-integrate us — this
 /// heals a WireGuard tunnel after one side restarts (the survivor otherwise
 /// treats the rejoiner as already-known and never re-advertises itself).
+///
+/// Nanosecond resolution avoids two restarts inside the same second colliding.
+/// CAVEAT: this is the REAL clock, so a large backwards wall-clock step (NTP or
+/// manual set) between two restarts could leave the newer incarnation below the
+/// stored one and miss the restart until the clock passes it again. Acceptable
+/// for restart healing; a persisted monotonic counter would be fully robust.
 fn incarnationNow() u64 {
-    return @intCast(std.Io.Timestamp.now(zio(), .real).toSeconds());
+    return @intCast(std.Io.Timestamp.now(zio(), .real).toNanoseconds());
 }
 
 pub const SwimConfig = struct {
@@ -119,6 +125,11 @@ pub const SwimProtocol = struct {
 
     // Handshake-retransmit rate limiting (re-initiate stalled/rejoining peers)
     last_handshake_retransmit_ns: i128 = 0,
+    // Only the userspace WG data plane needs SWIM to re-drive handshakes; the
+    // kernel WireGuard module retransmits its own (via keepalive), so enabling
+    // this in kernel/gossip-only modes would just churn peers + spam logs.
+    // Set true by the daemon only in userspace-TUN mode.
+    retransmit_handshakes: bool = false,
 
     // Pending pings awaiting ACK
     pending: [16]PendingPing = std.mem.zeroes([16]PendingPing),
@@ -1370,6 +1381,7 @@ pub const SwimProtocol = struct {
     /// can reach the rejoiner before it has re-learned us — and any dropped
     /// initial handshake. One pass per gossip interval.
     fn retransmitStalledHandshakes(self: *SwimProtocol, now_ns: i128) void {
+        if (!self.retransmit_handshakes) return; // userspace-TUN only (see field)
         const interval_ns: i128 = @as(i128, self.config.gossip_interval_ms) * 1_000_000;
         if (now_ns - self.last_handshake_retransmit_ns < interval_ns) return;
         self.last_handshake_retransmit_ns = now_ns;

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -117,6 +117,9 @@ pub const SwimProtocol = struct {
     // Ping rate limiting
     last_ping_sent_ns: i128 = 0,
 
+    // Handshake-retransmit rate limiting (re-initiate stalled/rejoining peers)
+    last_handshake_retransmit_ns: i128 = 0,
+
     // Pending pings awaiting ACK
     pending: [16]PendingPing = std.mem.zeroes([16]PendingPing),
     pending_count: usize = 0,
@@ -425,6 +428,8 @@ pub const SwimProtocol = struct {
         }
 
         // 5. Probe at most one unauthenticated candidate endpoint.
+        self.retransmitStalledHandshakes(now_ns);
+
         self.probeCandidatePeer(now_ns);
 
         // 6. Hole punch: send probes for active punches
@@ -484,6 +489,8 @@ pub const SwimProtocol = struct {
         }
 
         // 4. Probe at most one unauthenticated candidate endpoint.
+        self.retransmitStalledHandshakes(now_ns);
+
         self.probeCandidatePeer(now_ns);
 
         // 5. Hole punch: send probes for active punches
@@ -1352,6 +1359,27 @@ pub const SwimProtocol = struct {
         // init reaches the rejoiner before it has re-learned us.
         if (self.handler) |h| {
             h.onPeerDead(h.ctx, sender_pubkey);
+            h.onPeerJoin(h.ctx, peer);
+        }
+    }
+
+    /// Periodically re-drive handshakes for alive peers whose tunnel is not yet
+    /// up. Re-fires onPeerJoin, which the handler makes a no-op for peers with an
+    /// established session (WgDevice.hasActiveTunnel) and a (re)initiation for
+    /// stalled ones. Covers the post-restart init/ack race — our re-initiation
+    /// can reach the rejoiner before it has re-learned us — and any dropped
+    /// initial handshake. One pass per gossip interval.
+    fn retransmitStalledHandshakes(self: *SwimProtocol, now_ns: i128) void {
+        const interval_ns: i128 = @as(i128, self.config.gossip_interval_ms) * 1_000_000;
+        if (now_ns - self.last_handshake_retransmit_ns < interval_ns) return;
+        self.last_handshake_retransmit_ns = now_ns;
+        const h = self.handler orelse return;
+        var iter = self.membership.peers.iterator();
+        while (iter.next()) |entry| {
+            const peer = entry.value_ptr;
+            if (peer.state != .alive) continue;
+            if (peer.wg_pubkey == null) continue;
+            if (peer.gossip_endpoint == null and peer.public_endpoint == null) continue;
             h.onPeerJoin(h.ctx, peer);
         }
     }

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -1566,6 +1566,60 @@ fn issueCertWire(org_kp: Org.OrgKeyPair, node_pubkey: [32]u8, name: []const u8) 
     return cert_wire;
 }
 
+test "peer restart is detected by incarnation and steady state is not" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    var counter = JoinCounter{};
+    var swim = SwimProtocol.init(
+        &membership,
+        inertTestSocket(),
+        .{},
+        [_]u8{1} ** 32, // our_pubkey
+        [_]u8{2} ** 32, // our_wg_pubkey
+        .{ 127, 0, 0, 1 },
+        51821,
+        .{ .ctx = &counter, .onPeerJoin = countPeerJoin, .onPeerDead = ignorePeerDead },
+    );
+
+    const peer_pk = [_]u8{3} ** 32;
+    try membership.upsert(aliveTestPeer(peer_pk));
+
+    // First incarnation observed: recorded, NOT treated as a restart.
+    swim.handleSenderIncarnation(peer_pk, 100);
+    try std.testing.expectEqual(@as(u64, 100), membership.peers.get(peer_pk).?.incarnation);
+    try std.testing.expectEqual(@as(usize, 0), counter.count);
+
+    // Same incarnation (steady-state pings): no rejoin.
+    swim.handleSenderIncarnation(peer_pk, 100);
+    try std.testing.expectEqual(@as(usize, 0), counter.count);
+
+    // Lower incarnation (reordered/stale packet): no rejoin, no downgrade.
+    swim.handleSenderIncarnation(peer_pk, 50);
+    try std.testing.expectEqual(@as(usize, 0), counter.count);
+    try std.testing.expectEqual(@as(u64, 100), membership.peers.get(peer_pk).?.incarnation);
+
+    // Higher incarnation => the peer RESTARTED: rejoin (onPeerJoin re-fires) and
+    // the stored incarnation advances.
+    swim.handleSenderIncarnation(peer_pk, 200);
+    try std.testing.expectEqual(@as(usize, 1), counter.count);
+    try std.testing.expectEqual(peer_pk, counter.last_pubkey.?);
+    try std.testing.expectEqual(@as(u64, 200), membership.peers.get(peer_pk).?.incarnation);
+
+    // Incarnation 0 (peer predates the feature) is ignored.
+    swim.handleSenderIncarnation(peer_pk, 0);
+    try std.testing.expectEqual(@as(usize, 1), counter.count);
+
+    // Our own pubkey is ignored.
+    swim.handleSenderIncarnation([_]u8{1} ** 32, 999);
+    try std.testing.expectEqual(@as(usize, 1), counter.count);
+
+    // An unknown peer is ignored (no rejoin, no crash).
+    swim.handleSenderIncarnation([_]u8{9} ** 32, 999);
+    try std.testing.expectEqual(@as(usize, 1), counter.count);
+}
+
 test "gossiped join cannot admit an unauthorized subject with wg key" {
     const allocator = std.testing.allocator;
     var membership = Membership.MembershipTable.init(allocator, 5000);

--- a/src/main.zig
+++ b/src/main.zig
@@ -915,6 +915,9 @@ fn cmdUp(allocator: std.mem.Allocator, extra_args: []const []const u8) !void {
             .onPeerPunched = &wgOnPeerPunched,
         },
     );
+    // SWIM-driven handshake retransmit is only needed for the userspace WG data
+    // plane; kernel WireGuard retransmits its own, and gossip-only has none.
+    swim.retransmit_handshakes = !use_kernel_wg and !gossip_only;
 
     // Load authorized keys and enable trust enforcement (unless --open)
     if (!open_mode) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1746,6 +1746,11 @@ fn wgOnPeerJoin(ctx: *anyopaque, peer: *const lib.discovery.Membership.Peer) voi
                 };
             }
         } else if (handler.wg_device) |dev| {
+            // Already-established tunnel: this call is a periodic handshake
+            // retransmit for a peer that is already up — leave it untouched (do
+            // not re-add or rekey). Fresh joins and post-restart rejoins tear the
+            // peer down first (onPeerDead), so they are never established here.
+            if (dev.hasActiveTunnel(wg_key)) return;
             // Userspace mode: register peer in WgDevice
             const peer_endpoint: ?Endpoint = if (peer.gossip_endpoint) |ep| ep else if (peer.public_endpoint) |pub_ep| pub_ep else null;
 

--- a/src/protocol/codec.zig
+++ b/src/protocol/codec.zig
@@ -19,7 +19,7 @@ const ORG_CERT_EXTENSION_SIZE = 1 + messages.ORG_CERT_WIRE_SIZE;
 
 /// Encode a Ping message into a buffer. Returns bytes written.
 pub fn encodePing(buf: []u8, ping: messages.Ping) !usize {
-    const required = 1 + 32 + 8 + 1 + ping.gossip.len * GOSSIP_ENTRY_SIZE +
+    const required = 1 + 32 + 8 + 8 + 1 + ping.gossip.len * GOSSIP_ENTRY_SIZE +
         if (ping.has_org_cert) ORG_CERT_EXTENSION_SIZE else 0;
     if (buf.len < required) return error.BufferTooShort;
 
@@ -35,6 +35,10 @@ pub fn encodePing(buf: []u8, ping: messages.Ping) !usize {
 
     // Sequence
     std.mem.writeInt(u64, buf[pos..][0..8], ping.seq, .little);
+    pos += 8;
+
+    // Incarnation
+    std.mem.writeInt(u64, buf[pos..][0..8], ping.incarnation, .little);
     pos += 8;
 
     // Gossip entries
@@ -58,7 +62,7 @@ pub fn encodePing(buf: []u8, ping: messages.Ping) !usize {
 
 /// Encode an Ack message into a buffer. Returns bytes written.
 pub fn encodeAck(buf: []u8, ack: messages.Ack) !usize {
-    const required = 1 + 32 + 8 + 1 + ack.gossip.len * GOSSIP_ENTRY_SIZE +
+    const required = 1 + 32 + 8 + 8 + 1 + ack.gossip.len * GOSSIP_ENTRY_SIZE +
         if (ack.has_org_cert) ORG_CERT_EXTENSION_SIZE else 0;
     if (buf.len < required) return error.BufferTooShort;
 
@@ -71,6 +75,10 @@ pub fn encodeAck(buf: []u8, ack: messages.Ack) !usize {
     pos += 32;
 
     std.mem.writeInt(u64, buf[pos..][0..8], ack.seq, .little);
+    pos += 8;
+
+    // Incarnation
+    std.mem.writeInt(u64, buf[pos..][0..8], ack.incarnation, .little);
     pos += 8;
 
     const gossip_count: u8 = @intCast(@min(ack.gossip.len, 255));
@@ -346,6 +354,7 @@ pub const DecodedMessage = union(enum) {
 pub const DecodedPing = struct {
     sender_pubkey: [32]u8,
     seq: u64,
+    incarnation: u64 = 0,
     gossip_buf: [8]messages.GossipEntry = undefined,
     gossip_count: u8 = 0,
     org_cert: [messages.ORG_CERT_WIRE_SIZE]u8 = std.mem.zeroes([messages.ORG_CERT_WIRE_SIZE]u8),
@@ -360,6 +369,7 @@ pub const DecodedPing = struct {
 pub const DecodedAck = struct {
     sender_pubkey: [32]u8,
     seq: u64,
+    incarnation: u64 = 0,
     gossip_buf: [8]messages.GossipEntry = undefined,
     gossip_count: u8 = 0,
     org_cert: [messages.ORG_CERT_WIRE_SIZE]u8 = std.mem.zeroes([messages.ORG_CERT_WIRE_SIZE]u8),
@@ -392,7 +402,7 @@ pub fn decode(data: []const u8) DecodeError!DecodedMessage {
 }
 
 fn decodePing(data: []const u8) DecodeError!DecodedPing {
-    if (data.len < 32 + 8 + 1) return error.BufferTooShort;
+    if (data.len < 32 + 8 + 8 + 1) return error.BufferTooShort;
 
     var result = DecodedPing{
         .sender_pubkey = undefined,
@@ -401,10 +411,11 @@ fn decodePing(data: []const u8) DecodeError!DecodedPing {
 
     @memcpy(&result.sender_pubkey, data[0..32]);
     result.seq = std.mem.readInt(u64, data[32..40], .little);
+    result.incarnation = std.mem.readInt(u64, data[40..48], .little);
 
-    const advertised_gossip_count = @min(data[40], 8);
+    const advertised_gossip_count = @min(data[48], 8);
 
-    var pos: usize = 41;
+    var pos: usize = 49;
     var parsed_gossip_count: u8 = 0;
     for (0..advertised_gossip_count) |i| {
         if (pos + GOSSIP_ENTRY_SIZE > data.len) break;
@@ -420,7 +431,7 @@ fn decodePing(data: []const u8) DecodeError!DecodedPing {
 }
 
 fn decodeAck(data: []const u8) DecodeError!DecodedAck {
-    if (data.len < 32 + 8 + 1) return error.BufferTooShort;
+    if (data.len < 32 + 8 + 8 + 1) return error.BufferTooShort;
 
     var result = DecodedAck{
         .sender_pubkey = undefined,
@@ -429,10 +440,11 @@ fn decodeAck(data: []const u8) DecodeError!DecodedAck {
 
     @memcpy(&result.sender_pubkey, data[0..32]);
     result.seq = std.mem.readInt(u64, data[32..40], .little);
+    result.incarnation = std.mem.readInt(u64, data[40..48], .little);
 
-    const advertised_gossip_count = @min(data[40], 8);
+    const advertised_gossip_count = @min(data[48], 8);
 
-    var pos: usize = 41;
+    var pos: usize = 49;
     var parsed_gossip_count: u8 = 0;
     for (0..advertised_gossip_count) |i| {
         if (pos + GOSSIP_ENTRY_SIZE > data.len) break;

--- a/src/protocol/codec.zig
+++ b/src/protocol/codec.zig
@@ -2,8 +2,8 @@
 //!
 //! Format: [1B type][payload...]
 //!
-//! Ping:     [0x01][32B pubkey][8B seq][1B gossip_count][N × gossip_entry]
-//! Ack:      [0x03][32B pubkey][8B seq][1B gossip_count][N × gossip_entry]
+//! Ping:     [0x01][32B pubkey][8B seq][8B incarnation][1B gossip_count][N × gossip_entry][opt org_cert ext]
+//! Ack:      [0x03][32B pubkey][8B seq][8B incarnation][1B gossip_count][N × gossip_entry][opt org_cert ext]
 //! PingReq:  [0x02][32B sender][32B target][8B seq]
 //!
 //! GossipEntry endpoints: [1B has_ep][1B family: 4/6][16B addr][2B port]

--- a/src/protocol/messages.zig
+++ b/src/protocol/messages.zig
@@ -48,6 +48,11 @@ pub const Ping = struct {
     sender_pubkey: [32]u8,
     /// Monotonic sequence number
     seq: u64,
+    /// Sender's incarnation — a per-process startup epoch (seconds) that
+    /// increases every time the node restarts. Lets a peer that already knows
+    /// us detect that we RESTARTED (higher incarnation than it has stored) and
+    /// re-integrate us, healing the tunnel after a restart. 0 = not advertised.
+    incarnation: u64 = 0,
     /// Piggybacked gossip updates
     gossip: []const GossipEntry,
     /// Org certificate extension appended after gossip, if present.
@@ -67,6 +72,8 @@ pub const PingReq = struct {
 pub const Ack = struct {
     sender_pubkey: [32]u8,
     seq: u64,
+    /// Sender's incarnation (see Ping.incarnation). 0 = not advertised.
+    incarnation: u64 = 0,
     gossip: []const GossipEntry,
     /// Org certificate extension appended after gossip, if present.
     org_cert: [ORG_CERT_WIRE_SIZE]u8 = std.mem.zeroes([ORG_CERT_WIRE_SIZE]u8),

--- a/src/wireguard/device.zig
+++ b/src/wireguard/device.zig
@@ -423,6 +423,20 @@ pub const WgDevice = struct {
         return error.TooManyPeers;
     }
 
+    /// True if we hold an established transport session (a completed handshake)
+    /// for this peer. Lets the periodic handshake retransmit skip peers whose
+    /// tunnel is already up, so only stalled/rejoining peers are re-initiated.
+    pub fn hasActiveTunnel(self: *WgDevice, wg_pubkey: [32]u8) bool {
+        self.lock.lockUncancelable(zio());
+        defer self.lock.unlock(zio());
+        if (self.static_map.get(wg_pubkey)) |slot| {
+            if (self.peers[slot]) |*peer| {
+                return peer.active_tunnel != null;
+            }
+        }
+        return false;
+    }
+
     /// Remove a peer by WG public key.
     pub fn removePeer(self: *WgDevice, wg_pubkey: [32]u8) void {
         self.lock.lockUncancelable(zio()); // H6: exclusive — zeroes keys + nils the slot


### PR DESCRIPTION
## Problem

A MeshGuard node that **restarts with the same identity** is never re-integrated by peers that already know it. SWIM liveness stays healthy (pings/acks flow both ways), but the WireGuard tunnel never re-forms — 100% packet loss until *both* sides cold-restart.

Root cause is in `swim.zig`'s learn path: when a peer contacts us, a **new** peer takes the branch that re-advertises us (enqueues our join gossip with our `wg_pubkey`), but an **already-known** peer only hits `markAlive`. So a restarted peer — which came back with empty state — never re-learns us, never re-initiates the handshake, and the survivor keeps a stale WG session. Because the WG key is derived from the persistent identity (`SHA-512(seed)`), it doesn't change on restart, so there's no key delta to detect the restart by.

This is the "restart-reconverge" failure surfaced during the 3-node mesh dogfooding run (every hand-restart of a Phase-2 node hit it). It was initially mis-hypothesized as a staggered-cold-start key-exchange gap; a deterministic 2-instance network-namespace lab showed cold staggered start works fine on Linux and **restart** is the real bug.

## Fix — per-node incarnation + handshake retransmit

1. **Wire:** add an `incarnation` (startup wall-clock seconds, monotonic across restarts) to `Ping`/`Ack`, appended after `seq` (`messages.zig` + `codec.zig`). Stamped on every outgoing ping/ack.
2. **Detect:** `handleSenderIncarnation()` runs **only from the authenticated ping/ack handlers** (never from gossip). A known peer presenting a **higher** incarnation restarted; new/steady-state just records it. Because it acts only on the authenticated sender's own entry, a forged gossip "rejoin" cannot rebind or tear down a trusted peer's session.
3. **Re-integrate:** on a detected restart — re-advertise ourselves (bounded, queued gossip, so the rejoiner re-learns our identity + `wg_pubkey`) and `onPeerDead` + `onPeerJoin` to rebuild the WG peer (`addPeerWithEndpoint` otherwise reuses the stale completed slot).
4. **Retransmit:** the re-initiation raced ahead of the rejoiner re-learning us (its first init was dropped, and inits were one-shot). Added a rate-limited **handshake retransmit** in `tick()`/`tickTimersOnly()`: once per gossip interval, re-fire `onPeerJoin` for alive peers whose tunnel isn't up. New `WgDevice.hasActiveTunnel()` is the completion signal; `wgOnPeerJoin` is now a no-op for already-established peers, so re-firing is safe and only stalled/rejoining peers re-initiate.

## Validation

Deterministic 2-instance netns lab (each namespace gets its own `51821`) + `zig build test`:

- ✅ **Cold start** forms the tunnel, bidirectional ping — **no regression**
- ✅ **B restart** while A stays up → tunnel re-forms, ping A↔B 3/3
- ✅ **2nd B restart** → heals again (repeatable)
- ✅ **A-side restart** (symmetry) → heals both directions 3/3
- ✅ Suite **168/168** (adds a unit test for the detection logic: first incarnation recorded, same/lower ignored, higher triggers rejoin, and `0`/self/unknown ignored)

## Notes for review

- **Wire-format change**: `incarnation` is inserted after `seq`, so this is **not** wire-compatible with older nodes — the fleet needs a coordinated rebuild + restart. (Chosen over a trailing optional extension for simplicity; happy to switch to an append-after-`org_cert` extension if compatibility during rollout is preferred.)
- **`Peer.handshake_complete` is vestigial** — it's never set to `true` anywhere in the tree, so it can't be used as a completion signal. I left it untouched and used `hasActiveTunnel()` instead; worth either wiring it up or deleting it in a separate change.
- Still open from the same exercise: **#114** (no periodic wg-key re-advertisement) could not be reproduced on Linux and is suspected macOS/tailnet-specific — left open, off the critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
