### PR TITLE
fix: stability hardening — remote-crash, OOB, and cross-arch fixes

### DIFF
--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -1279,7 +1279,10 @@ pub const SwimProtocol = struct {
 
     fn collectGossip(self: *SwimProtocol) []const messages.GossipEntry {
         if (self.gossip_count == 0) return &.{};
-        const count = @min(self.gossip_count, self.config.max_gossip_per_message);
+        // Clamp to the snapshot buffer size as well: max_gossip_per_message is an
+        // operator-settable config value and could exceed gossip_snap.len, which
+        // would overflow the fixed buffer in the copy loop below.
+        const count = @min(@min(self.gossip_count, self.config.max_gossip_per_message), self.gossip_snap.len);
 
         // Copy entries into snapshot buffer
         for (0..count) |i| {
@@ -1290,8 +1293,9 @@ pub const SwimProtocol = struct {
         var write: usize = 0;
         for (0..self.gossip_count) |read| {
             if (read < count) {
-                // This entry was just sent — decrement
-                self.gossip_queue[read].remaining -= 1;
+                // This entry was just sent — decrement. Saturating: guards against a
+                // remaining==0 slot (max_gossip_broadcasts configured to 0) underflowing.
+                self.gossip_queue[read].remaining -|= 1;
             }
             if (self.gossip_queue[read].remaining > 0) {
                 if (write != read) {
@@ -1370,7 +1374,10 @@ pub const SwimProtocol = struct {
         // init reaches the rejoiner before it has re-learned us.
         if (self.handler) |h| {
             h.onPeerDead(h.ctx, sender_pubkey);
-            h.onPeerJoin(h.ctx, peer);
+            // Re-fetch: `peer` is a pointer into the membership hashmap. Per the
+            // handler contract onPeerDead may mutate membership (a rehash would
+            // dangle `peer`), so re-resolve before handing it to onPeerJoin.
+            if (self.membership.peers.getPtr(sender_pubkey)) |p| h.onPeerJoin(h.ctx, p);
         }
     }
 
@@ -1415,8 +1422,13 @@ pub const SwimProtocol = struct {
         // Self-suspicion refutation: if someone suspects/kills us, broadcast alive
         if (std.mem.eql(u8, &entry.subject_pubkey, &self.our_pubkey)) {
             if (entry.event == .suspect or entry.event == .dead) {
-                // Refute by broadcasting alive with higher Lamport clock
-                self.membership.lamport = @max(self.membership.lamport, entry.lamport) + 1;
+                // Refute by broadcasting alive with higher Lamport clock.
+                // SECURITY: entry.lamport is attacker-controlled (gossip is not
+                // per-entry authenticated, and the sender gate is open by default),
+                // so a single forged PING with lamport==u64 max would overflow this
+                // add — a panic (safe builds) or clock corruption (fast builds) from
+                // one packet. Saturate instead.
+                self.membership.lamport = @max(self.membership.lamport, entry.lamport) +| 1;
                 self.enqueueGossip(.{
                     .subject_pubkey = self.our_pubkey,
                     .event = .alive,
@@ -2104,4 +2116,37 @@ test "gossiped dead does not instantly evict a third party (H2 regression)" {
     // A replayed "alive" from gossip must NOT clear our local suspicion (M6).
     swim.applyGossip(.{ .subject_pubkey = victim, .event = .alive, .lamport = 100, .endpoint = messages.Endpoint.initV4(.{ 127, 0, 0, 1 }, 40000) });
     try std.testing.expect(membership.peers.get(victim).?.state == .suspected);
+}
+
+test "forged self-dead gossip with max Lamport does not overflow (S1)" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    var swim = SwimProtocol.init(&membership, inertTestSocket(), .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, null);
+
+    // Attacker-forged gossip claiming WE are dead, with a maxed-out Lamport clock.
+    // Pre-fix: `@max(lamport, u64max) + 1` overflowed -> panic (safe builds) from one packet.
+    swim.applyGossip(.{ .subject_pubkey = swim.our_pubkey, .event = .dead, .lamport = std.math.maxInt(u64), .endpoint = null });
+
+    // Saturated instead of wrapping; no crash.
+    try std.testing.expectEqual(@as(u64, std.math.maxInt(u64)), swim.membership.lamport);
+}
+
+test "collectGossip clamps to snapshot size and tolerates zero broadcasts (S3/S4)" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    // Misconfiguration: per-message cap far above gossip_snap.len, and zero broadcasts.
+    var swim = SwimProtocol.init(&membership, inertTestSocket(), .{ .max_gossip_per_message = 64, .max_gossip_broadcasts = 0 }, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, null);
+
+    var i: u8 = 0;
+    while (i < 20) : (i += 1) {
+        swim.enqueueGossip(.{ .subject_pubkey = [_]u8{i} ** 32, .event = .alive, .lamport = 1, .endpoint = null });
+    }
+
+    // Pre-fix: count == 20 overflowed gossip_snap[8..]; remaining==0 underflowed on decrement.
+    const out = swim.collectGossip();
+    try std.testing.expect(out.len <= swim.gossip_snap.len);
 }

--- a/src/net/batch_udp.zig
+++ b/src/net/batch_udp.zig
@@ -32,9 +32,10 @@ const Mmsghdr = extern struct {
     msg_len: u32,
 };
 
-// Syscall numbers (x86_64 Linux)
-const SYS_recvmmsg = 299;
-const SYS_sendmmsg = 307;
+// recvmmsg/sendmmsg/recvmsg/sendmsg syscall numbers are architecture-specific
+// (x86_64 differs from aarch64/arm/riscv). Use the target-correct std.os.linux.SYS
+// enum members below rather than hardcoded x86_64 integers, so non-x86_64 Linux
+// daemon builds invoke the right syscall instead of a wrong/nonexistent one.
 
 /// Pre-allocated batch receive state.
 /// After declaring, call `setupPointers()` to wire up internal self-references.
@@ -79,7 +80,7 @@ pub const BatchReceiver = struct {
         }
 
         const rc = linux.syscall6(
-            @enumFromInt(SYS_recvmmsg),
+            linux.SYS.recvmmsg,
             @as(usize, @intCast(fd)),
             @intFromPtr(&self.msgs),
             BATCH_SIZE,
@@ -149,7 +150,7 @@ pub const BatchSender = struct {
         if (self.count == 0) return 0;
 
         const rc = linux.syscall4(
-            @enumFromInt(SYS_sendmmsg),
+            linux.SYS.sendmmsg,
             @as(usize, @intCast(fd)),
             @intFromPtr(&self.msgs),
             self.count,
@@ -217,9 +218,8 @@ pub const GROReceiver = struct {
             .msg_flags = 0,
         };
 
-        // SYS_recvmsg = 47 on x86_64
         const rc = linux.syscall3(
-            @enumFromInt(47),
+            linux.SYS.recvmsg,
             @as(usize, @intCast(fd)),
             @intFromPtr(&hdr),
             @as(usize, linux.MSG.DONTWAIT),
@@ -335,9 +335,8 @@ pub const GSOSender = struct {
             .msg_flags = 0,
         };
 
-        // SYS_sendmsg = 46 on x86_64
         const rc = linux.syscall3(
-            @enumFromInt(46),
+            linux.SYS.sendmsg,
             @as(usize, @intCast(fd)),
             @intFromPtr(&hdr),
             @as(usize, linux.MSG.DONTWAIT),
@@ -424,7 +423,7 @@ pub const ZeroCopyGSOSender = struct {
         };
 
         const rc = linux.syscall3(
-            @enumFromInt(46), // SYS_sendmsg
+            linux.SYS.sendmsg,
             @as(usize, @intCast(fd)),
             @intFromPtr(&hdr),
             @as(usize, linux.MSG.DONTWAIT),

--- a/src/net/dns.zig
+++ b/src/net/dns.zig
@@ -201,7 +201,7 @@ pub fn queryMDNS(allocator: std.mem.Allocator, service_name: []const u8) ![][]co
     };
     if (comptime is_linux) {
         const rc = linux.sendto(sock_fd, query_buf[0..query_len].ptr, query_len, 0, @ptrCast(&mdns_addr), @sizeOf(@TypeOf(mdns_addr)));
-        if (posix.errno(rc) != .SUCCESS) return &.{};
+        if (rawSyscallFailed(rc)) return &.{};
     } else {
         if (std.c.sendto(sock_fd, query_buf[0..query_len].ptr, query_len, 0, @ptrCast(&mdns_addr), @sizeOf(@TypeOf(mdns_addr))) < 0) {
             return &.{};
@@ -429,11 +429,20 @@ fn closeFd(fd: posix.socket_t) void {
     }
 }
 
+/// Raw std.os.linux.* syscalls return -errno as a usize on failure. std.posix.errno
+/// misclassifies that when libc is linked (it only handles rv == -1 and reads the C
+/// errno global, which a raw syscall never sets), so a -errno slips through as
+/// "success" — the same class as the recvfrom OOB fixed in udp.zig. Decode the sign
+/// of the raw return directly instead of trusting posix.errno.
+fn rawSyscallFailed(rc: usize) bool {
+    return @as(isize, @bitCast(rc)) < 0;
+}
+
 /// Create a DGRAM socket (cross-platform).
 fn createDgramSocket() ?posix.socket_t {
     if (comptime is_linux) {
         const rc = linux.socket(linux.AF.INET, linux.SOCK.DGRAM, 0);
-        if (posix.errno(rc) != .SUCCESS) return null;
+        if (rawSyscallFailed(rc)) return null;
         return @intCast(@as(i32, @bitCast(@as(u32, @truncate(rc)))));
     } else if (comptime is_windows) {
         const sock = std.c.socket(std.c.AF.INET, std.c.SOCK.DGRAM, 0);
@@ -450,7 +459,7 @@ fn createDgramSocket() ?posix.socket_t {
 fn recvFromSocket(fd: posix.socket_t, buf: []u8) ?usize {
     if (comptime is_linux) {
         const rc = linux.recvfrom(fd, buf.ptr, buf.len, 0, null, null);
-        if (posix.errno(rc) != .SUCCESS) return null;
+        if (rawSyscallFailed(rc)) return null;
         return @intCast(rc);
     } else {
         const rc = std.c.recvfrom(fd, buf.ptr, buf.len, 0, null, null);
@@ -504,14 +513,14 @@ fn sendQuery(nameserver: [4]u8, port: u16, query: []const u8) ?QueryResponse {
     // connect we send with a null destination (the connected peer).
     if (comptime is_linux) {
         const crc = linux.connect(sock_fd, @ptrCast(&addr), @sizeOf(@TypeOf(addr)));
-        if (posix.errno(crc) != .SUCCESS) return null;
+        if (rawSyscallFailed(crc)) return null;
     } else {
         if (std.c.connect(sock_fd, @ptrCast(&addr), @sizeOf(@TypeOf(addr))) != 0) return null;
     }
 
     if (comptime is_linux) {
         const rc = linux.sendto(sock_fd, query.ptr, query.len, 0, null, 0);
-        if (posix.errno(rc) != .SUCCESS) return null;
+        if (rawSyscallFailed(rc)) return null;
     } else {
         if (std.c.sendto(sock_fd, query.ptr, query.len, 0, null, 0) < 0) return null;
     }

--- a/src/protocol/codec.zig
+++ b/src/protocol/codec.zig
@@ -467,7 +467,11 @@ fn decodeOrgCertExtension(
 ) DecodeError!void {
     if (pos >= data.len) return;
     if (data[pos] != 1) return;
-    if (pos + ORG_CERT_EXTENSION_SIZE > data.len) return error.BufferTooShort;
+    // A truncated/malformed trailing extension must not nullify an otherwise-valid
+    // SWIM packet (its liveness + gossip already parsed). Treat a short cert as "no
+    // cert present", mirroring the lenient gossip-entry loop, rather than failing the
+    // whole ping/ack decode.
+    if (pos + ORG_CERT_EXTENSION_SIZE > data.len) return;
     @memcpy(cert, data[pos + 1 ..][0..messages.ORG_CERT_WIRE_SIZE]);
     has_cert.* = true;
 }
@@ -859,6 +863,24 @@ test "org trust vouch roundtrip" {
             try std.testing.expectEqual(v.lamport, 777);
             try std.testing.expectEqualSlices(u8, &sig, &v.signature);
         },
+        else => return error.InvalidMessageType,
+    }
+}
+
+test "truncated trailing org-cert flag does not drop the whole packet (C4)" {
+    const pubkey = [_]u8{0x01} ** 32;
+    const ping = messages.Ping{ .sender_pubkey = pubkey, .seq = 7, .gossip = &.{} };
+
+    var buf: [600]u8 = undefined;
+    const written = try encodePing(&buf, ping);
+
+    // Append a stray cert-present flag (0x01) with no room for the 186-byte cert.
+    // Pre-fix this returned error.BufferTooShort and failed the ENTIRE decode,
+    // discarding otherwise-valid SWIM liveness + gossip.
+    buf[written] = 1;
+    const decoded = try decode(buf[0 .. written + 1]);
+    switch (decoded) {
+        .ping => |p| try std.testing.expect(!p.has_org_cert),
         else => return error.InvalidMessageType,
     }
 }


### PR DESCRIPTION
## Stability hardening sweep

An adversarial audit of the merged tree turned up several correctness/safety
bugs reachable from malformed network input, misconfiguration, or non-x86_64
builds. Each fix is small and self-contained; every finding was verified at the
source. Suite: **176/176** on Linux, and the tree now passes Zig semantic
analysis for `aarch64-linux` (only external libsodium blocks the full cross-link).

### Fixes

**`fix(swim)` — gossip apply hardening**
- **Critical: remote one-packet crash.** The self-refutation Lamport bump
  `@max(self.membership.lamport, entry.lamport) + 1` (`swim.zig`) used an
  attacker-controlled, un-authenticated `entry.lamport`. In the default open
  trust mode a single forged `PING` carrying gossip `{subject=us, event=.dead,
  lamport=0xFFFF_FFFF_FFFF_FFFF}` overflows the add → panic in Debug/ReleaseSafe
  (the default build), or Lamport-clock corruption in ReleaseFast. Now uses a
  saturating `+|`.
- Clamp `collectGossip`'s count to the snapshot buffer size — `max_gossip_per_message`
  is operator-configurable and could exceed the fixed 8-slot `gossip_snap` → OOB write.
- Saturating decrement of the broadcast counter (guards `max_gossip_broadcasts == 0`).
- Re-fetch the peer pointer after `onPeerDead` before passing it to `onPeerJoin`
  in the incarnation rejoin path (defensive against a handler that mutates membership).
- Regression tests for the overflow and the config-bound cases.

**`fix(dns)` — raw-syscall errno decode (OOB)**
`dns.zig` checked raw `std.os.linux.*` syscall returns with `std.posix.errno`,
which under linked libc only classifies `rv == -1` and reads the C `errno` global
(never set by a raw syscall) — so a `-errno` slipped through as success. On the
`recvfrom` path this returned the negated errno as a huge "length" into the DNS
parser (OOB read). This is the same class already fixed for `recvfrom` in
`udp.zig`; applied the sign-decode consistently across all five raw-syscall sites.

**`fix(net)` — arch-correct batch-UDP syscalls**
`batch_udp.zig` hardcoded x86_64 syscall numbers (`recvmmsg=299`, `sendmmsg=307`,
`recvmsg=47`, `sendmsg=46`) while gated only on `os == linux`. On aarch64/arm/riscv
Linux these invoke the wrong syscall (silent no-op or worse). Switched to the
target-correct `std.os.linux.SYS` enum members. (`io_uring.zig` was fine — it uses
liburing ops, which are arch-independent.)

**`fix(codec)` — tolerate a truncated trailing org-cert extension**
A ping/ack ending with a cert-present flag but fewer than the full 187 trailing
bytes returned `error.BufferTooShort` and failed the entire decode, discarding
otherwise-valid SWIM liveness + gossip. Now treated as "no cert present",
mirroring the lenient gossip-entry loop. Regression test added.

### Not in this PR
The audit also surfaced several issues in the WireGuard data plane (anti-replay
lock scope, session-expiry handling, simultaneous-init tie-breaker), the FFI
lifecycle, and NAT/token handling. Those either need a design decision or touch
concurrency/wire-format and are being handled separately.
