### PR TITLE
fix: WireGuard anti-replay/expiry + FFI resume-thread races

### DIFF
--- a/src/meshguard_ffi.zig
+++ b/src/meshguard_ffi.zig
@@ -98,6 +98,10 @@ pub const MeshguardContext = struct {
     event_loop_thread: ?std.Thread,
     running: std.atomic.Value(bool),
     suspended: std.atomic.Value(bool), // low-power mode: recv only, no send
+    // Set by meshguard_resume() on the host thread; consumed by the event-loop
+    // thread, which owns SWIM/LAN state, to perform the post-resume re-announce
+    // without racing tick(). See meshguard_resume / eventLoop.
+    resume_requested: std.atomic.Value(bool),
 
     // Callbacks (set by host app)
     on_message_cb: ?*const fn ([*]const u8, usize, [*]const u8) callconv(.c) void,
@@ -138,6 +142,7 @@ fn initContextStorage(allocator: std.mem.Allocator) MeshguardContext {
         .event_loop_thread = null,
         .running = std.atomic.Value(bool).init(false),
         .suspended = std.atomic.Value(bool).init(false),
+        .resume_requested = std.atomic.Value(bool).init(false),
         .on_message_cb = null,
         .on_peer_event_cb = null,
         .on_undeliverable_cb = null,
@@ -752,14 +757,12 @@ export fn meshguard_resume(ctx: ?*MeshguardContext) void {
 
     if (was_suspended) {
         std.debug.print("  ▶️  meshguard resumed — re-pinging all peers\n", .{});
-        // Force immediate ping to all alive peers to refresh state
-        if (c.swim) |*swim| {
-            swim.pingAllAlive();
-        }
-        // Fire a LAN beacon immediately to re-discover nearby peers
-        if (c.lan_discovery) |*lan| {
-            lan.sendBeacon();
-        }
+        // Defer the actual re-announce (pingAllAlive + LAN beacon) to the event-loop
+        // thread. Those mutate SWIM/LAN state the loop owns — seq, pending[], the
+        // gossip queue, membership iteration — so running them here on the host thread
+        // races the loop's tick() (torn pending_count, iterator invalidation). Flip an
+        // atomic and let the loop do it next active tick, mirroring how suspend works.
+        c.resume_requested.store(true, .release);
     }
 }
 
@@ -1065,6 +1068,14 @@ fn eventLoop(ctx: *MeshguardContext) void {
             } else {
                 // ACTIVE: full gossip + discovery
                 swim.tick() catch {};
+
+                // Honor a pending resume() (requested from the host thread): do the
+                // immediate re-announce HERE, on the loop thread that owns SWIM/LAN
+                // state, so it can't race tick().
+                if (ctx.resume_requested.swap(false, .acq_rel)) {
+                    swim.pingAllAlive();
+                    if (ctx.lan_discovery) |*lan| lan.sendBeacon();
+                }
             }
 
             // LAN discovery: only in active mode

--- a/src/wireguard/device.zig
+++ b/src/wireguard/device.zig
@@ -431,7 +431,12 @@ pub const WgDevice = struct {
         defer self.lock.unlock(zio());
         if (self.static_map.get(wg_pubkey)) |slot| {
             if (self.peers[slot]) |*peer| {
-                return peer.active_tunnel != null;
+                // Honor session expiry: a non-null but expired (>= REJECT_AFTER_TIME)
+                // tunnel can no longer encrypt or decrypt, so it must NOT count as
+                // active — otherwise the periodic handshake retransmit and re-init
+                // gates skip it and the dead session is never re-established.
+                if (peer.active_tunnel) |*t| return t.isValid();
+                return false;
             }
         }
         return false;

--- a/src/wireguard/tunnel.zig
+++ b/src/wireguard/tunnel.zig
@@ -218,7 +218,10 @@ pub const Tunnel = struct {
 
         const counter = std.mem.readInt(u64, packet[8..16], .little);
 
-        // Anti-replay check (mutex-protected for multi-thread)
+        // Early anti-replay reject (optimization: avoid decrypting an obvious
+        // replay). NOT authoritative — the counter is re-checked and marked
+        // atomically after authentication below, which is what actually prevents
+        // the TOCTOU replay across concurrent decrypt workers.
         {
             self.replay_lock.lockUncancelable(zio());
             defer self.replay_lock.unlock(zio());
@@ -247,8 +250,19 @@ pub const Tunnel = struct {
             self.keys.receiving_key,
         ) catch return error.DecryptionFailed;
 
-        // Update replay window
-        self.replay_window.update(counter);
+        // Authoritative anti-replay: re-check and mark the counter atomically under
+        // the lock, AFTER authentication succeeds. The early check() above released
+        // its lock before the decrypt, so two decrypt workers (the pipeline runs N)
+        // could both pass it for the same counter and both deliver the packet — a
+        // TOCTOU replay — while racing the window bitmap. Doing check()+update() as
+        // one locked step is the WireGuard-correct behavior: the second worker's
+        // check() now fails and it is rejected.
+        {
+            self.replay_lock.lockUncancelable(zio());
+            defer self.replay_lock.unlock(zio());
+            if (!self.replay_window.check(counter)) return error.ReplayedPacket;
+            self.replay_window.update(counter);
+        }
         self.last_recv_ns = nowNs();
 
         // Strip padding: parse IP header to get real packet length
@@ -273,7 +287,7 @@ pub const Tunnel = struct {
     pub fn isValid(self: *const Tunnel) bool {
         const elapsed = nowNs() - self.keys.birthdate_ns;
         return elapsed < REJECT_AFTER_TIME_NS and
-            self.send_counter < REJECT_AFTER_MESSAGES;
+            self.send_counter.load(.monotonic) < REJECT_AFTER_MESSAGES;
     }
 
     /// Check if a keepalive should be sent.
@@ -545,4 +559,57 @@ test "transport tunnel deinit zeros keys" {
         if (b != 0) all_zeros = false;
     }
     try std.testing.expect(all_zeros);
+}
+
+test "isValid honors session expiry (W3)" {
+    const fresh = Tunnel{ .keys = .{
+        .sending_key = .{0x11} ** 32,
+        .receiving_key = .{0x22} ** 32,
+        .sending_index = 1,
+        .receiving_index = 2,
+        .is_initiator = true,
+        .birthdate_ns = nowNs(),
+    } };
+    try std.testing.expect(fresh.isValid());
+
+    // A session past REJECT_AFTER_TIME can no longer en/decrypt; isValid must say so
+    // (this is what lets hasActiveTunnel report it inactive so it gets re-established).
+    const expired = Tunnel{ .keys = .{
+        .sending_key = .{0x11} ** 32,
+        .receiving_key = .{0x22} ** 32,
+        .sending_index = 1,
+        .receiving_index = 2,
+        .is_initiator = true,
+        .birthdate_ns = nowNs() - REJECT_AFTER_TIME_NS - std.time.ns_per_s,
+    } };
+    try std.testing.expect(!expired.isValid());
+}
+
+test "replayed transport packet is rejected (W1 atomic check+update)" {
+    const keys = noise.TransportKeys{
+        .sending_key = .{0x42} ** 32,
+        .receiving_key = .{0x99} ** 32,
+        .sending_index = 1,
+        .receiving_index = 2,
+        .is_initiator = true,
+        .birthdate_ns = nowNs(),
+    };
+    var sender = Tunnel{ .keys = keys };
+    var receiver = Tunnel{ .keys = .{
+        .sending_key = keys.receiving_key,
+        .receiving_key = keys.sending_key,
+        .sending_index = keys.receiving_index,
+        .receiving_index = keys.sending_index,
+        .is_initiator = false,
+        .birthdate_ns = keys.birthdate_ns,
+    } };
+
+    var pkt: [256]u8 = undefined;
+    var out: [256]u8 = undefined;
+    const n = try sender.encrypt("replay me", &pkt);
+
+    _ = try receiver.decrypt(pkt[0..n], &out); // first delivery accepted
+    // Same counter again -> rejected. Verifies the reordered check+update still marks
+    // the counter so a replay is caught (single-thread correctness of the W1 fix).
+    try std.testing.expectError(error.ReplayedPacket, receiver.decrypt(pkt[0..n], &out));
 }


### PR DESCRIPTION
## WireGuard data-plane + FFI concurrency fixes

Three concurrency/lifecycle correctness bugs found while auditing the data plane.
Each was verified at the source; suite 174/174 on Linux with added regression tests.

### `fix(wireguard)` — anti-replay check+update is now atomic
`Tunnel.decrypt` took `replay_lock` only for the initial `check()`, released it,
then called `replay_window.update()` **unlocked**. With the decrypt pipeline
running N workers, two workers can pop two copies of the same counter, both pass
the early `check()` before either marks it, and both deliver the packet — a
TOCTOU replay — while racing the window bitmap. The early `check()` is kept as an
optimization (skip decrypting an obvious replay), but the authoritative
`check()`+`update()` is now a single atomic step under the lock, after
authentication, so the second worker is rejected. Also revives `Tunnel.isValid()`,
which was dead code comparing the atomic `send_counter` without loading it.

### `fix(wireguard)` — `hasActiveTunnel` honors session expiry
`hasActiveTunnel` returned `active_tunnel != null` with no expiry check. A session
past `REJECT_AFTER_TIME` (180s) can no longer encrypt/decrypt, but `active_tunnel`
is never nulled — so the periodic handshake retransmit and re-init gates treated
the dead session as healthy and never re-established it (a userspace tunnel could
silently die at the 180s mark). Now consults `Tunnel.isValid()`, so an expired
session reports inactive and gets re-handshaked.

### `fix(ffi)` — resume re-announce runs on the event-loop thread
`meshguard_resume()` called `pingAllAlive()` and `sendBeacon()` directly on the
host caller thread. Those mutate SWIM/LAN state owned by the event-loop thread
(`seq`, `pending[]`, the gossip queue, membership iteration), so a resume racing
the loop's `tick()` could tear `pending_count` (OOB write) or invalidate the
membership iterator. It now flips an atomic `resume_requested` and the loop
performs the re-announce on its own thread next active tick — mirroring how
suspend already works.

### Tests
- Replayed transport packet is rejected (single-thread correctness of the reorder).
- `isValid` reports a fresh session valid and an expired one invalid.
