### PR TITLE
fix(swim): periodically re-advertise wg_pubkey to heal 2-node tunnels (#114)

### DIFF
--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -445,6 +445,7 @@ pub const SwimProtocol = struct {
 
         // 5. Probe at most one unauthenticated candidate endpoint.
         self.retransmitStalledHandshakes(now_ns);
+        self.readvertiseSelf(now_ns);
 
         self.probeCandidatePeer(now_ns);
 
@@ -1355,6 +1356,10 @@ pub const SwimProtocol = struct {
         if (self.config.self_readvertise_interval_ms == 0) return; // disabled
         const interval_ns: i128 = @as(i128, self.config.self_readvertise_interval_ms) * 1_000_000;
         if (self.last_self_readvertise_ns != 0 and now_ns - self.last_self_readvertise_ns < interval_ns) return;
+        // Only advance the timer if we can actually enqueue — a full gossip queue
+        // would otherwise suppress the re-advertisement for a whole interval without
+        // having queued anything (enqueueGossip is a silent no-op when full).
+        if (self.gossip_count >= self.gossip_queue.len) return;
         self.last_self_readvertise_ns = now_ns;
         self.enqueueSelfGossip();
     }
@@ -2197,6 +2202,6 @@ test "periodic self re-advertise re-offers our wg_pubkey (heals #114)" {
 
     // Rate-limited: a second call within the interval does NOT enqueue again.
     const before = swim.gossip_count;
-    swim.readvertiseSelf(5_000_000_500); // 500ns later, far inside the 1ms interval
+    swim.readvertiseSelf(5_000_000_500); // 500ns later, far inside the 1s (1000ms) interval
     try std.testing.expectEqual(before, swim.gossip_count);
 }

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -48,6 +48,10 @@ pub const SwimConfig = struct {
     ping_req_count: u32 = 3,
     max_gossip_per_message: u32 = 8,
     max_gossip_broadcasts: u32 = 6, // how many times to broadcast each gossip entry
+    // How often to re-advertise our own identity + wg_pubkey into gossip so a peer
+    // that missed the one-shot registration-time advertisement still learns our WG
+    // key (issue #114). 0 disables. Default 30s.
+    self_readvertise_interval_ms: u32 = 30000,
 };
 
 /// Callback interface for SWIM events (e.g. WireGuard peer management).
@@ -125,6 +129,7 @@ pub const SwimProtocol = struct {
 
     // Handshake-retransmit rate limiting (re-initiate stalled/rejoining peers)
     last_handshake_retransmit_ns: i128 = 0,
+    last_self_readvertise_ns: i128 = 0,
     // Only the userspace WG data plane needs SWIM to re-drive handshakes; the
     // kernel WireGuard module retransmits its own (via keepalive), so enabling
     // this in kernel/gossip-only modes would just churn peers + spam logs.
@@ -501,6 +506,7 @@ pub const SwimProtocol = struct {
 
         // 4. Probe at most one unauthenticated candidate endpoint.
         self.retransmitStalledHandshakes(now_ns);
+        self.readvertiseSelf(now_ns);
 
         self.probeCandidatePeer(now_ns);
 
@@ -1336,6 +1342,23 @@ pub const SwimProtocol = struct {
         });
     }
 
+    /// Periodically re-advertise our own identity + wg_pubkey into gossip (issue
+    /// #114). wg_pubkey is otherwise offered only at one-shot registration time, so a
+    /// peer that missed it — a dropped advertisement, a staggered join, or a
+    /// gossip-only -> userspace-WG transition where we had no key to give — never
+    /// learns it and, in a 2-node mesh, has no third party to re-gossip it, so the
+    /// tunnel never forms despite healthy SWIM. This is bounded/queued
+    /// (enqueueSelfGossip -> max_gossip_broadcasts) and a no-op at the receiver for
+    /// peers that already hold our key (applyGossip binds wg_pubkey set-once), so it
+    /// heals the gap without disturbing established tunnels. One re-advert per interval.
+    fn readvertiseSelf(self: *SwimProtocol, now_ns: i128) void {
+        if (self.config.self_readvertise_interval_ms == 0) return; // disabled
+        const interval_ns: i128 = @as(i128, self.config.self_readvertise_interval_ms) * 1_000_000;
+        if (self.last_self_readvertise_ns != 0 and now_ns - self.last_self_readvertise_ns < interval_ns) return;
+        self.last_self_readvertise_ns = now_ns;
+        self.enqueueSelfGossip();
+    }
+
     /// Detect and heal a peer restart from an AUTHENTICATED ping/ack. If the
     /// sender's incarnation exceeds what we have stored, it restarted with the
     /// same identity: the survivor otherwise keeps it as already-known and never
@@ -2149,4 +2172,31 @@ test "collectGossip clamps to snapshot size and tolerates zero broadcasts (S3/S4
     // Pre-fix: count == 20 overflowed gossip_snap[8..]; remaining==0 underflowed on decrement.
     const out = swim.collectGossip();
     try std.testing.expect(out.len <= swim.gossip_snap.len);
+}
+
+test "periodic self re-advertise re-offers our wg_pubkey (heals #114)" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    const our_wg = [_]u8{0xAB} ** 32;
+    var swim = SwimProtocol.init(&membership, inertTestSocket(), .{ .self_readvertise_interval_ms = 1000 }, [_]u8{1} ** 32, our_wg, .{ 127, 0, 0, 1 }, 51821, null);
+
+    // Steady state: the one-shot registration-time advertisement has already drained.
+    swim.gossip_count = 0;
+
+    // Interval elapsed -> we re-offer our identity + wg_pubkey (exactly what a peer
+    // stuck with a null wg_pubkey for us needs to initiate the handshake). Pre-fix
+    // this never happened, so #114's 2-node tunnel never formed.
+    swim.readvertiseSelf(5_000_000_000);
+    try std.testing.expect(swim.gossip_count >= 1);
+    const e = swim.gossip_queue[0].entry;
+    try std.testing.expectEqual(swim.our_pubkey, e.subject_pubkey);
+    try std.testing.expect(e.wg_pubkey != null);
+    try std.testing.expectEqual(our_wg, e.wg_pubkey.?);
+
+    // Rate-limited: a second call within the interval does NOT enqueue again.
+    const before = swim.gossip_count;
+    swim.readvertiseSelf(5_000_000_500); // 500ns later, far inside the 1ms interval
+    try std.testing.expectEqual(before, swim.gossip_count);
 }


### PR DESCRIPTION
Fixes #114.

## Problem
`wg_pubkey` is advertised into gossip **only at one-shot peer-registration time**;
steady-state pings drain an empty gossip queue and carry no key. If that
advertisement doesn't reach a userspace-WG counterpart — a dropped packet, a
staggered join, or a `--gossip-only` → userspace-WG transition where the node had
no key to give when the peer registered it — the key is **never learned and never
re-offered**. A 2-node mesh has no third party to re-gossip it, so the WireGuard
tunnel never forms even though SWIM membership looks fully healthy.

## Fix
A bounded, rate-limited **periodic re-advertisement** of our own identity +
`wg_pubkey`, via the existing `enqueueSelfGossip` path, driven from
`tick()`/`tickTimersOnly()` (new `self_readvertise_interval_ms`, default 30s;
`0` disables). This is the issue's own **suggested fix #1** and needs **no
wire-format change**.

Two properties keep it safe:
- **No-op for healthy peers** — the receiver binds `wg_pubkey` set-once
  (`applyGossip`), so re-advertising to a peer that already has our key changes
  nothing and never re-fires `onPeerJoin`. Established tunnels are undisturbed.
- **Queued/bounded** — it re-enqueues through the normal
  `max_gossip_broadcasts` queue, exactly like the registration-time and restart
  (incarnation) advertisements that already work. It is deliberately **not** the
  constant per-message self-advert that regressed cold-start in an earlier
  experiment.

## Verification
- **Unit test** (`swim.zig`): after the interval elapses, the gossip queue carries
  our identity + `wg_pubkey` again (what a peer stuck with a null key needs), and
  a second call inside the interval does not re-enqueue (rate-limited).
- **2-node netns TUN lab**: cold start still forms a bidirectional encrypted
  tunnel with ping 3/3 both ways — **no cold-start regression** (the failure mode
  of the naive approach).
- Full suite green (182/182).

Note: the restart-triggered subcases are already healed by the incarnation
re-advertise added in #117; this closes the remaining missed-advertisement /
gossip-only residual with a periodic safety net.
