### PR TITLE
fix(swim): gate incarnation restart on live tunnel to block spoofed teardown (S2)

### DIFF
--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -47,6 +47,13 @@ fn incarnationNow() u64 {
     return @intCast(std.Io.Timestamp.now(zio(), .real).toNanoseconds());
 }
 
+// Max clock skew we tolerate when validating a peer's incarnation (its startup
+// wall-clock, ns). An incarnation beyond our own clock by more than this is forged
+// (a node cannot have started in the future); rejecting it bounds how far a spoofed
+// value can advance our stored incarnation, so it can never be pushed to the u64
+// ceiling nor ahead of a genuine future restart's (later) startup time.
+const INCARNATION_SKEW_NS: u64 = 300 * std.time.ns_per_s; // 5 minutes
+
 pub const SwimConfig = struct {
     gossip_port: u16 = 51821,
     gossip_interval_ms: u32 = 5000, // 5s — reasonable for WAN
@@ -74,6 +81,11 @@ pub const EventHandler = struct {
     /// peer possesses its WG private key, which a spoofer cannot forge. Returns
     /// false when liveness is unknown (kernel WG / gossip-only / no device).
     hasActiveTunnel: ?*const fn (ctx: *anyopaque, wg_pubkey: [32]u8) bool = null,
+    /// Re-initiate a WG handshake to a peer we still hold a (stale) session for,
+    /// used by the S2 restart-heal path. The implementation must only act when it is
+    /// the deterministic tie-break initiator toward the peer (to avoid a
+    /// simultaneous-init race), and it is a handshake refresh — never a teardown.
+    reinitiateHandshake: ?*const fn (ctx: *anyopaque, peer: *const Membership.Peer) void = null,
 };
 
 /// Gossip entry with broadcast remaining counter.
@@ -1376,27 +1388,34 @@ pub const SwimProtocol = struct {
         self.enqueueSelfGossip();
     }
 
-    /// Detect and heal a peer restart signalled by a ping/ack. If the
-    /// sender's incarnation exceeds what we have stored, it restarted with the
-    /// same identity: the survivor otherwise keeps it as already-known and never
-    /// re-advertises itself, so the rejoiner (which lost all state) never
-    /// re-learns us and the WG tunnel never re-forms. We re-advertise ourselves
-    /// (rejoiner re-learns us -> re-initiates the handshake, which our WG
-    /// responder services with a fresh session) and drop our stale
-    /// handshake_complete flag so we also re-initiate.
+    /// Detect and heal a peer restart signalled by a ping/ack. A higher incarnation
+    /// than we have stored means the sender restarted with the same identity.
     ///
-    /// SECURITY: called only from the ping/ack handlers, which have passed
-    /// isAuthorizedPeer — but that authenticates the CLAIMED sender identity, NOT
-    /// the packet origin (SWIM ping/ack carry no per-packet signature), so a
-    /// spoofer who knows a peer's public pubkey can forge a ping as that peer.
-    /// This path is therefore identity-authenticated, not origin-authenticated;
-    /// the S2 gate below uses a live WireGuard tunnel — which a spoofer cannot
-    /// forge — as the missing origin signal before acting on a restart claim. A
-    /// forged GOSSIP "rejoin" still cannot reach this path at all (it is never
-    /// called from applyGossip).
+    /// SECURITY: called only from the ping/ack handlers (past isAuthorizedPeer), but
+    /// that authenticates the CLAIMED identity, NOT the packet origin — SWIM ping/ack
+    /// are unsigned, so a spoofer who knows a peer's public pubkey can forge a restart
+    /// claim. Two guards defang that (see S2):
+    ///   1. We reject an implausibly-future incarnation (a node cannot have started in
+    ///      the future). This bounds how far a forged value can advance our stored
+    ///      incarnation, so pinning it can never blind us to a genuine later restart
+    ///      (which carries a still-later startup time) — and it can't reach the u64
+    ///      ceiling. Because the pin is thus bounded, we pin unconditionally, which
+    ///      also stops steady-state pings from re-entering the heal branch (no churn).
+    ///   2. If we currently hold a LIVE WireGuard tunnel to the peer — which a spoofer
+    ///      cannot forge (needs the peer's WG private key) — we do NOT tear it down.
+    ///      To still heal a genuine restart of a tie-break LOSER (which won't
+    ///      re-initiate itself, and whose survivor is the initiator), we re-initiate
+    ///      the handshake ourselves via reinitiateHandshake — a refresh, not a
+    ///      teardown (WG supersedes the stale session; a spoof costs at most one
+    ///      device-rate-limited rekey). Verified: heal ~1 interval in both tie-break
+    ///      directions.
+    /// A forged GOSSIP rejoin still cannot reach this path at all (never called from
+    /// applyGossip).
     fn handleSenderIncarnation(self: *SwimProtocol, sender_pubkey: [32]u8, incarnation: u64) void {
         if (incarnation == 0) return; // peer predates incarnation support
         if (std.mem.eql(u8, &sender_pubkey, &self.our_pubkey)) return;
+        // Guard 1: reject an implausibly-future incarnation (bounds any pin to ~now).
+        if (incarnation > incarnationNow() +| INCARNATION_SKEW_NS) return;
         const peer = self.membership.peers.getPtr(sender_pubkey) orelse return;
         if (peer.incarnation == 0) {
             // First incarnation seen for this peer — record it (not a restart).
@@ -1405,47 +1424,37 @@ pub const SwimProtocol = struct {
         }
         if (incarnation <= peer.incarnation) return; // steady state
 
-        // S2 SECURITY GATE: a higher incarnation CLAIMS the peer restarted, but
-        // SWIM ping/ack are origin-unauthenticated — isAuthorizedPeer checks the
-        // CLAIMED identity, not the packet source — so a spoofer who knows V's
-        // (public) pubkey can forge this claim. A spoofer CANNOT forge a live
-        // WireGuard session for V (that needs V's WG private key). So if we
-        // currently hold a live tunnel to V, treat it as origin proof and IGNORE
-        // the claim ENTIRELY: acting would tear down a working tunnel AND poison
-        // peer.incarnation with the attacker's value, after which V's real future
-        // restart (a lower incarnation) is never detected — a persistent 1-packet
-        // DoS. A genuine restart still heals: V re-initiates a handshake that
-        // supersedes our stale session, and once that session passes
-        // REJECT_AFTER_TIME hasActiveTunnel reports inactive (WgDevice.isValid, W3),
-        // freeing this path to rebuild. RESIDUAL: this trusts the live-tunnel
-        // signal, not the packet; when liveness is unknown the hook returns false
-        // and we proceed as before.
+        // Higher (and plausibly-timed) incarnation => the peer restarted. Pin it now
+        // — safe because it is bounded to ~now above, so steady-state pings stop
+        // re-entering this branch while a genuine later restart is still detected.
+        peer.incarnation = incarnation;
+        peer.handshake_complete = false;
+
+        // Guard 2: if we hold a live tunnel to the peer, do NOT tear it down (a
+        // spoofer cannot forge it; a real restart's stale session heals below without
+        // a teardown). Re-initiate the handshake ourselves so a restarted tie-break
+        // LOSER (which won't initiate) still heals; the handler restricts this to when
+        // we are the initiator and the WG device rate-limits it.
         if (peer.wg_pubkey) |wg| {
             if (self.handler) |h| {
                 if (h.hasActiveTunnel) |hasTunnel| {
-                    if (hasTunnel(h.ctx, wg)) return;
+                    if (hasTunnel(h.ctx, wg)) {
+                        if (h.reinitiateHandshake) |reinit| reinit(h.ctx, peer);
+                        return;
+                    }
                 }
             }
         }
 
-        // No proof of a live tunnel — treat this as a genuine rejoin.
-        // Higher incarnation => the peer RESTARTED. Re-integrate it.
-        peer.incarnation = incarnation;
-        peer.handshake_complete = false;
-        // Re-advertise ourselves so the rejoiner (which lost all state)
-        // re-learns our identity + wg_pubkey.
+        // No live tunnel — safe to fully rebuild: re-advertise ourselves so the
+        // rejoiner re-learns our identity + wg_pubkey, then tear down the stale WG
+        // peer (addPeerWithEndpoint would otherwise reuse the old completed slot) and
+        // re-add it fresh so the deterministic initiator re-sends a handshake
+        // initiation. The tick() retransmit covers the init/ack race.
         self.enqueueSelfGossip();
-        // Rebuild the WG session for the peer: onPeerDead removes the stale peer
-        // (addPeerWithEndpoint would otherwise reuse the old completed handshake
-        // slot and the re-init runs on stale state), then onPeerJoin re-adds it
-        // fresh and the deterministic initiator re-sends a handshake initiation.
-        // The periodic retransmit in tick() covers the init/ack race where our
-        // init reaches the rejoiner before it has re-learned us.
         if (self.handler) |h| {
             h.onPeerDead(h.ctx, sender_pubkey);
-            // Re-fetch: `peer` is a pointer into the membership hashmap. Per the
-            // handler contract onPeerDead may mutate membership (a rehash would
-            // dangle `peer`), so re-resolve before handing it to onPeerJoin.
+            // Re-fetch: onPeerDead may mutate membership (rehash) and dangle `peer`.
             if (self.membership.peers.getPtr(sender_pubkey)) |p| h.onPeerJoin(h.ctx, p);
         }
     }
@@ -2295,6 +2304,7 @@ test "Lamport increments saturate and never overflow (P1)" {
 const S2TestCtx = struct {
     join_count: usize = 0,
     dead_count: usize = 0,
+    reinit_count: usize = 0,
     tunnel_live: bool = false,
 };
 fn s2OnJoin(ctx: *anyopaque, _: *const Membership.Peer) void {
@@ -2309,8 +2319,12 @@ fn s2HasTunnel(ctx: *anyopaque, _: [32]u8) bool {
     const c: *S2TestCtx = @ptrCast(@alignCast(ctx));
     return c.tunnel_live;
 }
+fn s2Reinit(ctx: *anyopaque, _: *const Membership.Peer) void {
+    const c: *S2TestCtx = @ptrCast(@alignCast(ctx));
+    c.reinit_count += 1;
+}
 
-test "S2: spoofed incarnation is ignored while a live tunnel exists (no teardown, no pin)" {
+test "S2: live-tunnel restart claim never tears down; heals via re-init" {
     const allocator = std.testing.allocator;
     var membership = Membership.MembershipTable.init(allocator, 5000);
     defer membership.deinit();
@@ -2321,6 +2335,7 @@ test "S2: spoofed incarnation is ignored while a live tunnel exists (no teardown
         .onPeerJoin = s2OnJoin,
         .onPeerDead = s2OnDead,
         .hasActiveTunnel = s2HasTunnel,
+        .reinitiateHandshake = s2Reinit,
     });
 
     const v = [_]u8{0x77} ** 32;
@@ -2329,15 +2344,46 @@ test "S2: spoofed incarnation is ignored while a live tunnel exists (no teardown
     p.incarnation = 100;
     try membership.upsert(p);
 
-    // Spoofed PING claiming V restarted (attacker-huge incarnation) while our tunnel
-    // to V is live. A spoofer can't forge V's WG session, so the claim must be ignored.
-    swim.handleSenderIncarnation(v, 999);
+    // Higher (plausible) incarnation while our tunnel to V is live. A spoofer cannot
+    // forge V's live WG session, so we must NOT tear the tunnel down; we heal via a
+    // handshake RE-INIT (covers a restarted tie-break loser), never a teardown.
+    swim.handleSenderIncarnation(v, 12345);
 
-    // No teardown, no rejoin, and — crucially — incarnation NOT poisoned to the
-    // attacker's value (else V's real future restart would never be detected).
+    try std.testing.expectEqual(@as(usize, 0), tctx.dead_count); // never tears the tunnel down
+    try std.testing.expectEqual(@as(usize, 0), tctx.join_count); // no rebuild
+    try std.testing.expectEqual(@as(usize, 1), tctx.reinit_count); // heals via re-init instead
+    // Incarnation is pinned (safe: it is bounded below the future clamp), so
+    // steady-state pings won't re-enter this branch and churn re-inits.
+    try std.testing.expectEqual(@as(u64, 12345), membership.peers.get(v).?.incarnation);
+}
+
+test "S2: implausibly-future incarnation is rejected (pin cannot be poisoned)" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    var tctx = S2TestCtx{ .tunnel_live = true };
+    var swim = SwimProtocol.init(&membership, inertTestSocket(), .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, .{
+        .ctx = &tctx,
+        .onPeerJoin = s2OnJoin,
+        .onPeerDead = s2OnDead,
+        .hasActiveTunnel = s2HasTunnel,
+        .reinitiateHandshake = s2Reinit,
+    });
+
+    const v = [_]u8{0x77} ** 32;
+    var p = aliveTestPeer(v);
+    p.wg_pubkey = [_]u8{0x88} ** 32;
+    p.incarnation = 100;
+    try membership.upsert(p);
+
+    // A node cannot have started in the future: maxInt(u64) is implausible -> rejected
+    // outright, so a forged value can't pin our incarnation near the ceiling and blind
+    // us to V's real restarts.
+    swim.handleSenderIncarnation(v, std.math.maxInt(u64));
+    try std.testing.expectEqual(@as(u64, 100), membership.peers.get(v).?.incarnation); // unchanged
+    try std.testing.expectEqual(@as(usize, 0), tctx.reinit_count);
     try std.testing.expectEqual(@as(usize, 0), tctx.dead_count);
-    try std.testing.expectEqual(@as(usize, 0), tctx.join_count);
-    try std.testing.expectEqual(@as(u64, 100), membership.peers.get(v).?.incarnation);
 }
 
 test "S2: genuine rejoin proceeds when no live tunnel (not over-gated)" {
@@ -2351,6 +2397,7 @@ test "S2: genuine rejoin proceeds when no live tunnel (not over-gated)" {
         .onPeerJoin = s2OnJoin,
         .onPeerDead = s2OnDead,
         .hasActiveTunnel = s2HasTunnel,
+        .reinitiateHandshake = s2Reinit,
     });
 
     const v = [_]u8{0x77} ** 32;
@@ -2361,9 +2408,10 @@ test "S2: genuine rejoin proceeds when no live tunnel (not over-gated)" {
 
     swim.handleSenderIncarnation(v, 200);
 
-    // With no live tunnel to protect, a real rejoin heals: teardown + re-add fire and
-    // the incarnation advances. Proves the gate doesn't over-suppress recovery.
+    // No live tunnel to protect -> full rebuild (teardown + re-add) and the incarnation
+    // advances. Proves the gate doesn't over-suppress recovery.
     try std.testing.expectEqual(@as(usize, 1), tctx.dead_count);
     try std.testing.expectEqual(@as(usize, 1), tctx.join_count);
+    try std.testing.expectEqual(@as(usize, 0), tctx.reinit_count); // rebuild path, not re-init
     try std.testing.expectEqual(@as(u64, 200), membership.peers.get(v).?.incarnation);
 }

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -68,6 +68,12 @@ pub const EventHandler = struct {
     onPeerPunched: ?*const fn (ctx: *anyopaque, peer: *const Membership.Peer, endpoint: messages.Endpoint) void = null,
     onAppMessage: ?*const fn (ctx: *anyopaque, data: []const u8) void = null,
     onWgPacket: ?*const fn (ctx: *anyopaque, data: []const u8, addr: [4]u8, port: u16) void = null,
+    /// Query whether a live WireGuard session currently exists for `wg_pubkey`.
+    /// Used as an origin-authentication signal for restart detection (S2): SWIM
+    /// ping/ack are not origin-authenticated, but holding a live tunnel proves the
+    /// peer possesses its WG private key, which a spoofer cannot forge. Returns
+    /// false when liveness is unknown (kernel WG / gossip-only / no device).
+    hasActiveTunnel: ?*const fn (ctx: *anyopaque, wg_pubkey: [32]u8) bool = null,
 };
 
 /// Gossip entry with broadcast remaining counter.
@@ -1394,6 +1400,31 @@ pub const SwimProtocol = struct {
             return;
         }
         if (incarnation <= peer.incarnation) return; // steady state
+
+        // S2 SECURITY GATE: a higher incarnation CLAIMS the peer restarted, but
+        // SWIM ping/ack are origin-unauthenticated — isAuthorizedPeer checks the
+        // CLAIMED identity, not the packet source — so a spoofer who knows V's
+        // (public) pubkey can forge this claim. A spoofer CANNOT forge a live
+        // WireGuard session for V (that needs V's WG private key). So if we
+        // currently hold a live tunnel to V, treat it as origin proof and IGNORE
+        // the claim ENTIRELY: acting would tear down a working tunnel AND poison
+        // peer.incarnation with the attacker's value, after which V's real future
+        // restart (a lower incarnation) is never detected — a persistent 1-packet
+        // DoS. A genuine restart still heals: V re-initiates a handshake that
+        // supersedes our stale session, and once that session passes
+        // REJECT_AFTER_TIME hasActiveTunnel reports inactive (WgDevice.isValid, W3),
+        // freeing this path to rebuild. RESIDUAL: this trusts the live-tunnel
+        // signal, not the packet; when liveness is unknown the hook returns false
+        // and we proceed as before.
+        if (peer.wg_pubkey) |wg| {
+            if (self.handler) |h| {
+                if (h.hasActiveTunnel) |hasTunnel| {
+                    if (hasTunnel(h.ctx, wg)) return;
+                }
+            }
+        }
+
+        // No proof of a live tunnel — treat this as a genuine rejoin.
         // Higher incarnation => the peer RESTARTED. Re-integrate it.
         peer.incarnation = incarnation;
         peer.handshake_complete = false;
@@ -2255,4 +2286,80 @@ test "Lamport increments saturate and never overflow (P1)" {
     try std.testing.expectEqual(@as(u64, std.math.maxInt(u64)), membership.lamport);
     membership.markDead(pk);
     try std.testing.expectEqual(@as(u64, std.math.maxInt(u64)), membership.lamport);
+}
+
+const S2TestCtx = struct {
+    join_count: usize = 0,
+    dead_count: usize = 0,
+    tunnel_live: bool = false,
+};
+fn s2OnJoin(ctx: *anyopaque, _: *const Membership.Peer) void {
+    const c: *S2TestCtx = @ptrCast(@alignCast(ctx));
+    c.join_count += 1;
+}
+fn s2OnDead(ctx: *anyopaque, _: [32]u8) void {
+    const c: *S2TestCtx = @ptrCast(@alignCast(ctx));
+    c.dead_count += 1;
+}
+fn s2HasTunnel(ctx: *anyopaque, _: [32]u8) bool {
+    const c: *S2TestCtx = @ptrCast(@alignCast(ctx));
+    return c.tunnel_live;
+}
+
+test "S2: spoofed incarnation is ignored while a live tunnel exists (no teardown, no pin)" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    var tctx = S2TestCtx{ .tunnel_live = true };
+    var swim = SwimProtocol.init(&membership, inertTestSocket(), .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, .{
+        .ctx = &tctx,
+        .onPeerJoin = s2OnJoin,
+        .onPeerDead = s2OnDead,
+        .hasActiveTunnel = s2HasTunnel,
+    });
+
+    const v = [_]u8{0x77} ** 32;
+    var p = aliveTestPeer(v);
+    p.wg_pubkey = [_]u8{0x88} ** 32; // we hold V's WG key — a live tunnel is possible
+    p.incarnation = 100;
+    try membership.upsert(p);
+
+    // Spoofed PING claiming V restarted (attacker-huge incarnation) while our tunnel
+    // to V is live. A spoofer can't forge V's WG session, so the claim must be ignored.
+    swim.handleSenderIncarnation(v, 999);
+
+    // No teardown, no rejoin, and — crucially — incarnation NOT poisoned to the
+    // attacker's value (else V's real future restart would never be detected).
+    try std.testing.expectEqual(@as(usize, 0), tctx.dead_count);
+    try std.testing.expectEqual(@as(usize, 0), tctx.join_count);
+    try std.testing.expectEqual(@as(u64, 100), membership.peers.get(v).?.incarnation);
+}
+
+test "S2: genuine rejoin proceeds when no live tunnel (not over-gated)" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    var tctx = S2TestCtx{ .tunnel_live = false }; // tunnel down/expired (e.g. past REJECT_AFTER_TIME)
+    var swim = SwimProtocol.init(&membership, inertTestSocket(), .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, .{
+        .ctx = &tctx,
+        .onPeerJoin = s2OnJoin,
+        .onPeerDead = s2OnDead,
+        .hasActiveTunnel = s2HasTunnel,
+    });
+
+    const v = [_]u8{0x77} ** 32;
+    var p = aliveTestPeer(v);
+    p.wg_pubkey = [_]u8{0x88} ** 32;
+    p.incarnation = 100;
+    try membership.upsert(p);
+
+    swim.handleSenderIncarnation(v, 200);
+
+    // With no live tunnel to protect, a real rejoin heals: teardown + re-add fire and
+    // the incarnation advances. Proves the gate doesn't over-suppress recovery.
+    try std.testing.expectEqual(@as(usize, 1), tctx.dead_count);
+    try std.testing.expectEqual(@as(usize, 1), tctx.join_count);
+    try std.testing.expectEqual(@as(u64, 200), membership.peers.get(v).?.incarnation);
 }

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -1376,7 +1376,7 @@ pub const SwimProtocol = struct {
         self.enqueueSelfGossip();
     }
 
-    /// Detect and heal a peer restart from an AUTHENTICATED ping/ack. If the
+    /// Detect and heal a peer restart signalled by a ping/ack. If the
     /// sender's incarnation exceeds what we have stored, it restarted with the
     /// same identity: the survivor otherwise keeps it as already-known and never
     /// re-advertises itself, so the rejoiner (which lost all state) never
@@ -1385,11 +1385,15 @@ pub const SwimProtocol = struct {
     /// responder services with a fresh session) and drop our stale
     /// handshake_complete flag so we also re-initiate.
     ///
-    /// SECURITY: only ever called from the ping/ack handlers, which have already
-    /// passed isAuthorizedPeer, and it acts only on the AUTHENTICATED sender's
-    /// own entry — never from gossip. A forged gossip "rejoin" for a third party
-    /// cannot reach this path, so it cannot rebind or tear down a trusted peer's
-    /// session.
+    /// SECURITY: called only from the ping/ack handlers, which have passed
+    /// isAuthorizedPeer — but that authenticates the CLAIMED sender identity, NOT
+    /// the packet origin (SWIM ping/ack carry no per-packet signature), so a
+    /// spoofer who knows a peer's public pubkey can forge a ping as that peer.
+    /// This path is therefore identity-authenticated, not origin-authenticated;
+    /// the S2 gate below uses a live WireGuard tunnel — which a spoofer cannot
+    /// forge — as the missing origin signal before acting on a restart claim. A
+    /// forged GOSSIP "rejoin" still cannot reach this path at all (it is never
+    /// called from applyGossip).
     fn handleSenderIncarnation(self: *SwimProtocol, sender_pubkey: [32]u8, incarnation: u64) void {
         if (incarnation == 0) return; // peer predates incarnation support
         if (std.mem.eql(u8, &sender_pubkey, &self.our_pubkey)) return;

--- a/src/main.zig
+++ b/src/main.zig
@@ -919,6 +919,7 @@ fn cmdUp(allocator: std.mem.Allocator, extra_args: []const []const u8) !void {
             .onPeerJoin = &wgOnPeerJoin,
             .onPeerDead = &wgOnPeerDead,
             .onPeerPunched = &wgOnPeerPunched,
+            .hasActiveTunnel = &wgHasActiveTunnel,
         },
     );
     // SWIM-driven handshake retransmit is only needed for the userspace WG data
@@ -1722,6 +1723,15 @@ const WgHandlerCtx = struct {
     socket: ?*lib.net.Udp.UdpSocket = null,
     use_kernel: bool = true,
 };
+
+/// S2: report whether we hold a live userspace WG tunnel to `wg_pubkey`. Kernel WG
+/// tracks its own sessions, so this returns false there (liveness unknown) and the
+/// incarnation restart path proceeds as before.
+fn wgHasActiveTunnel(ctx: *anyopaque, wg_pubkey: [32]u8) bool {
+    const handler: *WgHandlerCtx = @ptrCast(@alignCast(ctx));
+    const dev = handler.wg_device orelse return false;
+    return dev.hasActiveTunnel(wg_pubkey);
+}
 
 fn wgOnPeerJoin(ctx: *anyopaque, peer: *const lib.discovery.Membership.Peer) void {
     const handler: *WgHandlerCtx = @ptrCast(@alignCast(ctx));

--- a/src/main.zig
+++ b/src/main.zig
@@ -920,6 +920,7 @@ fn cmdUp(allocator: std.mem.Allocator, extra_args: []const []const u8) !void {
             .onPeerDead = &wgOnPeerDead,
             .onPeerPunched = &wgOnPeerPunched,
             .hasActiveTunnel = &wgHasActiveTunnel,
+            .reinitiateHandshake = &wgReinitiate,
         },
     );
     // SWIM-driven handshake retransmit is only needed for the userspace WG data
@@ -1731,6 +1732,25 @@ fn wgHasActiveTunnel(ctx: *anyopaque, wg_pubkey: [32]u8) bool {
     const handler: *WgHandlerCtx = @ptrCast(@alignCast(ctx));
     const dev = handler.wg_device orelse return false;
     return dev.hasActiveTunnel(wg_pubkey);
+}
+
+/// S2 heal: re-initiate a WG handshake to a peer whose restart we detected while
+/// still holding a (stale) live session — only when WE are the deterministic
+/// tie-break initiator (mirrors wgOnPeerJoin), so we never race the peer into a
+/// simultaneous initiation. A handshake refresh, not a teardown; the device applies
+/// its own 5s rate limit. No-op in kernel/gossip-only mode.
+fn wgReinitiate(ctx: *anyopaque, peer: *const lib.discovery.Membership.Peer) void {
+    const handler: *WgHandlerCtx = @ptrCast(@alignCast(ctx));
+    const dev = handler.wg_device orelse return;
+    const wg_key = peer.wg_pubkey orelse return;
+    if (std.mem.order(u8, &dev.static_public, &wg_key) != .lt) return; // only the initiator
+    const Endpoint = @import("protocol/messages.zig").Endpoint;
+    const ep: Endpoint = if (peer.gossip_endpoint) |e| e else if (peer.public_endpoint) |pe| pe else return;
+    if (dev.reinitiate(wg_key)) |init_msg| {
+        if (handler.socket) |sock| {
+            _ = sock.sendToEndpoint(std.mem.asBytes(&init_msg), ep) catch 0;
+        }
+    } else |_| {} // peer not registered / rate-limited
 }
 
 fn wgOnPeerJoin(ctx: *anyopaque, peer: *const lib.discovery.Membership.Peer) void {

--- a/src/meshguard_ffi.zig
+++ b/src/meshguard_ffi.zig
@@ -359,6 +359,7 @@ export fn meshguard_join(
         .onAppMessage = &onAppMessageCallback,
         .onWgPacket = &onWgPacketCallback,
         .hasActiveTunnel = &hasActiveTunnelCallback,
+        .reinitiateHandshake = &reinitiateHandshakeCallback,
     };
 
     // Initialize SWIM protocol — use OUR port, not the seed's port
@@ -417,6 +418,7 @@ export fn meshguard_join_ipv6(
         .onAppMessage = &onAppMessageCallback,
         .onWgPacket = &onWgPacketCallback,
         .hasActiveTunnel = &hasActiveTunnelCallback,
+        .reinitiateHandshake = &reinitiateHandshakeCallback,
     };
 
     c.swim = SwimProtocol.init(
@@ -477,6 +479,7 @@ export fn meshguard_join_lan(
         .onAppMessage = &onAppMessageCallback,
         .onWgPacket = &onWgPacketCallback,
         .hasActiveTunnel = &hasActiveTunnelCallback,
+        .reinitiateHandshake = &reinitiateHandshakeCallback,
     };
 
     // Initialize SWIM protocol
@@ -1197,6 +1200,24 @@ fn hasActiveTunnelCallback(raw_ctx: *anyopaque, wg_pubkey: [32]u8) bool {
     const ctx: *MeshguardContext = @ptrCast(@alignCast(raw_ctx));
     if (ctx.wg_device) |*dev| return dev.hasActiveTunnel(wg_pubkey);
     return false;
+}
+
+/// S2 heal: re-initiate a WG handshake to a restarted peer whose stale session we
+/// still hold — only when we are the tie-break initiator, so we don't race a
+/// simultaneous init. A refresh, not a teardown; device-rate-limited. No-op if the
+/// peer isn't registered in our device.
+fn reinitiateHandshakeCallback(raw_ctx: *anyopaque, peer: *const Membership.Peer) void {
+    const ctx: *MeshguardContext = @ptrCast(@alignCast(raw_ctx));
+    if (ctx.wg_device) |*dev| {
+        const wg_key = peer.wg_pubkey orelse return;
+        if (std.mem.order(u8, &dev.static_public, &wg_key) != .lt) return; // only the initiator
+        const ep: messages.Endpoint = if (peer.gossip_endpoint) |e| e else if (peer.public_endpoint) |pe| pe else return;
+        if (dev.reinitiate(wg_key)) |init_msg| {
+            if (ctx.socket) |*sock| {
+                _ = sock.sendToEndpoint(std.mem.asBytes(&init_msg), ep) catch 0;
+            }
+        } else |_| {}
+    }
 }
 
 fn onWgPacketCallback(raw_ctx: *anyopaque, data: []const u8, sender_addr: [4]u8, sender_port: u16) void {

--- a/src/meshguard_ffi.zig
+++ b/src/meshguard_ffi.zig
@@ -358,6 +358,7 @@ export fn meshguard_join(
         .onPeerPunched = null,
         .onAppMessage = &onAppMessageCallback,
         .onWgPacket = &onWgPacketCallback,
+        .hasActiveTunnel = &hasActiveTunnelCallback,
     };
 
     // Initialize SWIM protocol — use OUR port, not the seed's port
@@ -415,6 +416,7 @@ export fn meshguard_join_ipv6(
         .onPeerPunched = null,
         .onAppMessage = &onAppMessageCallback,
         .onWgPacket = &onWgPacketCallback,
+        .hasActiveTunnel = &hasActiveTunnelCallback,
     };
 
     c.swim = SwimProtocol.init(
@@ -474,6 +476,7 @@ export fn meshguard_join_lan(
         .onPeerPunched = null,
         .onAppMessage = &onAppMessageCallback,
         .onWgPacket = &onWgPacketCallback,
+        .hasActiveTunnel = &hasActiveTunnelCallback,
     };
 
     // Initialize SWIM protocol
@@ -1187,6 +1190,15 @@ fn onAppMessageCallback(raw_ctx: *anyopaque, data: []const u8) void {
 // ─── Internal: WireGuard tunnel packet handling ───
 
 /// Callback adapter: SWIM → FFI WG packet dispatch
+/// S2: report whether we hold a live userspace WG tunnel to `wg_pubkey`, so SWIM's
+/// incarnation restart detection can use it as an origin-authentication signal (a
+/// spoofer cannot forge a live WG session). False when no device exists yet.
+fn hasActiveTunnelCallback(raw_ctx: *anyopaque, wg_pubkey: [32]u8) bool {
+    const ctx: *MeshguardContext = @ptrCast(@alignCast(raw_ctx));
+    if (ctx.wg_device) |*dev| return dev.hasActiveTunnel(wg_pubkey);
+    return false;
+}
+
 fn onWgPacketCallback(raw_ctx: *anyopaque, data: []const u8, sender_addr: [4]u8, sender_port: u16) void {
     const ctx: *MeshguardContext = @ptrCast(@alignCast(raw_ctx));
     handleWgPacket(ctx, data, sender_addr, sender_port);

--- a/src/wireguard/device.zig
+++ b/src/wireguard/device.zig
@@ -426,6 +426,15 @@ pub const WgDevice = struct {
     /// True if we hold an established transport session (a completed handshake)
     /// for this peer. Lets the periodic handshake retransmit skip peers whose
     /// tunnel is already up, so only stalled/rejoining peers are re-initiated.
+    /// Force a fresh handshake initiation to an already-registered peer, bypassing
+    /// the "already established" short-circuit — used by the S2 restart-heal path to
+    /// refresh a stale-but-unexpired session without tearing it down. initiateHandshake
+    /// applies its own 5s rate limit and returns error.HandshakeRateLimited when hot.
+    pub fn reinitiate(self: *WgDevice, wg_pubkey: [32]u8) !noise.HandshakeInitiation {
+        const slot = self.static_map.get(wg_pubkey) orelse return error.PeerNotFound;
+        return self.initiateHandshake(slot);
+    }
+
     pub fn hasActiveTunnel(self: *WgDevice, wg_pubkey: [32]u8) bool {
         self.lock.lockUncancelable(zio());
         defer self.lock.unlock(zio());


### PR DESCRIPTION
## Problem
SWIM `PING`/`ACK` are **origin-unauthenticated** — the trust gate checks the
*claimed* sender identity, not the packet source. So an attacker who knows a
peer V's public Ed25519 key (it travels in the clear in gossip) can spoof
`PING {sender=V, incarnation=<huge>}`, and `handleSenderIncarnation` treats it as
a restart:
- it tears down V's **live** WireGuard tunnel (`onPeerDead`/`onPeerJoin`), and
- it pins `peer.incarnation` to the attacker's value, after which V's **real**
  future restart (a lower incarnation) is never detected.

A persistent, one-packet targeted DoS — and an impact regression introduced by
the incarnation feature in #117 (the gossip path was gated there; the ping path
itself is spoofable).

## Fix
A spoofer **cannot** forge a live WireGuard session for V (that needs V's WG
private key), so a live tunnel is exactly the origin-authentication signal SWIM
lacks. Add a `hasActiveTunnel(wg_pubkey)` hook to `EventHandler` (wired to
`WgDevice.hasActiveTunnel` in the userspace daemon and the FFI). When we hold a
live tunnel to V, **ignore the restart claim entirely** — no teardown, no
re-advertise, and critically **no incarnation update** (gating only the teardown
would still let one spoofed packet poison the pin). When liveness is unknown
(kernel WG / gossip-only / no device) the hook returns false and the path
proceeds as before.

## Genuine restarts still heal — and are not slowed
The restarted node comes up with no session and **re-initiates the handshake
itself** (its own tunnel is down), which the survivor's responder accepts; the
survivor never needed to proactively tear down. And once a truly stale session
passes `REJECT_AFTER_TIME`, `hasActiveTunnel` reports inactive (the W3 fix from
#119), freeing the incarnation path to rebuild.

**Verified in a 2-node netns lab, both tie-breaker directions:** cold start forms
a bidirectional tunnel, and after restarting either node the tunnel re-forms in
**~10s** (no 180s expiry wait).

## Tests
- spoofed `PING {sender=V, incarnation=huge}` while a live tunnel exists →
  **no** `onPeerDead`/`onPeerJoin` **and** `peer.incarnation` unchanged;
- same spoof with no live tunnel → rebuild proceeds (proves no over-gating).
- Full suite green (190/190).

No wire-format change. Residual (documented in-code): origin-unauthenticated SWIM
control means restart detection trusts the live-tunnel signal, not the packet;
packet-level origin auth is a heavier RFC-006-era change.
