### PR TITLE
fix: support cross-platform status and down

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,9 @@ meshguard up --seed 1.2.3.4:51821
 meshguard up --seed 1.2.3.4:51821 --kernel
 
 # Check status
-# Linux only in the current CLI
 meshguard status
 
 # Stop
-# Linux only in the current CLI
 meshguard down
 ```
 
@@ -376,7 +374,7 @@ Core functionality is implemented and under active benchmarking:
 - [x] Ed25519 keygen, save/load, sign/verify
 - [x] Authorized keys directory management
 - [x] Deterministic mesh IP derivation (Blake3)
-- [x] CLI: `keygen`, `trust`, `revoke`, `export`, `up`, `down`, `status`, `version` (`down`/`status` are Linux-only today)
+- [x] CLI: `keygen`, `trust`, `revoke`, `export`, `up`, `down`, `status`, `version`
 - [x] SWIM gossip protocol with Lamport clocks
 - [x] Binary wire protocol codec
 - [x] Kernel WireGuard via netlink (RTM_NEWLINK + Genetlink)

--- a/docs/guide/freebsd-support.md
+++ b/docs/guide/freebsd-support.md
@@ -36,5 +36,6 @@ sudo meshguard up --seed 1.2.3.4:51821
 ## Notes
 
 - Kernel WireGuard mode is Linux-only; FreeBSD uses the portable userspace data plane.
+- `meshguard status` and `meshguard down` use the Unix control socket while the userspace daemon is running.
 - GSO/GRO and io_uring paths are Linux-specific and are not used on FreeBSD.
 - The default config directory follows the POSIX rules: `/etc/meshguard` as root, otherwise `$XDG_CONFIG_HOME/meshguard` or `~/.config/meshguard`.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -150,8 +150,9 @@ meshguard will:
 meshguard down
 ```
 
-This tears down the `mg0` interface. In the current CLI this command is
-Linux-only; on other platforms stop the running process or service.
+When a userspace daemon is running, this requests a graceful shutdown through
+the control socket. On Linux, if no daemon control socket answers, it falls back
+to removing the kernel `mg0` interface.
 
 ### 6. Check status
 
@@ -159,7 +160,9 @@ Linux-only; on other platforms stop the running process or service.
 meshguard status
 ```
 
-In the current CLI, `status` is Linux-only.
+When a userspace daemon is running, this reports the node public key, mesh IP,
+and membership counts from the control socket. On Linux, if no control socket
+answers, it falls back to kernel `mg0` status where available.
 
 ## Run as a service
 

--- a/docs/guide/macos-support.md
+++ b/docs/guide/macos-support.md
@@ -50,5 +50,6 @@ meshguard up --gossip-only --seed 1.2.3.4:51821
 ## Notes
 
 - Kernel WireGuard mode is Linux-only; macOS uses the portable userspace data plane.
+- `meshguard status` and `meshguard down` use the Unix control socket while the userspace daemon is running.
 - GSO/GRO and io_uring paths are Linux-specific and are not used on macOS.
 - The default config directory follows the POSIX rules: `/etc/meshguard` as root, otherwise `$XDG_CONFIG_HOME/meshguard` or `~/.config/meshguard`.

--- a/docs/guide/windows-support.md
+++ b/docs/guide/windows-support.md
@@ -1,8 +1,8 @@
 # Windows Support
 
 > **Status**: Supported for userspace daemon operation with Wintun. Key management
-> and `meshguard up` work on Windows; `status` and `down` are still Linux-only in
-> the current CLI.
+> and `meshguard up` work on Windows; `status` and `down` use the Windows named
+> pipe control socket for running userspace daemons.
 
 ## Install
 
@@ -54,8 +54,8 @@ meshguard up --announce 203.0.113.42
 | `meshguard version` | ✅ | |
 | `meshguard config show` | ✅ | |
 | `meshguard up` | ✅ | Requires Admin + wintun.dll |
-| `meshguard status` | Linux-only | Windows control socket plumbing exists, but the CLI command is not wired yet |
-| `meshguard down` | Linux-only | Stop the running process or service manually |
+| `meshguard status` | ✅ | Queries `\\.\pipe\meshguard` while the daemon is running |
+| `meshguard down` | ✅ | Requests graceful daemon shutdown through `\\.\pipe\meshguard` |
 
 ## Architecture
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -99,14 +99,17 @@ meshguard up [options]
 
 ## `meshguard down`
 
-Stop the daemon and remove the `mg0` interface.
+Stop the daemon.
 
 ```bash
 meshguard down
 ```
 
-> **Platform:** Linux only. The current implementation uses `RTM_DELLINK` via
-> RTNETLINK to remove the interface.
+When a userspace daemon is running, this sends a graceful stop request through
+the control socket (`/run/meshguard/meshguard.sock`, the per-user config socket
+fallback, or `\\.\pipe\meshguard` on Windows). On Linux, if no control socket
+answers, `meshguard down` falls back to RTNETLINK teardown for the kernel `mg0`
+interface.
 
 ---
 
@@ -118,8 +121,10 @@ Display the current mesh state.
 meshguard status
 ```
 
-> **Platform:** Linux only. The current implementation queries `mg0` through
-> RTNETLINK and kernel WireGuard Genetlink where available.
+When a userspace daemon is running, this queries the control socket and reports
+the node public key, mesh IP, and membership counts. On Linux, if no control
+socket answers, `meshguard status` falls back to RTNETLINK and kernel WireGuard
+Genetlink for `mg0` where available.
 
 ---
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -925,6 +925,7 @@ fn cmdUp(allocator: std.mem.Allocator, extra_args: []const []const u8) !void {
     // SWIM-driven handshake retransmit is only needed for the userspace WG data
     // plane; kernel WireGuard retransmits its own, and gossip-only has none.
     swim.retransmit_handshakes = !use_kernel_wg and !gossip_only;
+    control.setStopFlag(&swim.running);
 
     // Load authorized keys and enable trust enforcement (unless --open)
     if (!open_mode) {
@@ -3524,23 +3525,32 @@ fn parseIpv6Endpoint(s: []const u8, port: u16) ?@import("protocol/messages.zig")
 }
 
 fn cmdDown(allocator: std.mem.Allocator) !void {
-    _ = allocator;
     const stdout = getStdOut();
     const stderr = getStdErr();
 
-    if (comptime @import("builtin").os.tag != .linux) {
-        try stderr.writeStreamingAll(zio(), "error: 'meshguard down' is only supported on Linux (requires netlink)\n");
+    var response_buf: [1024]u8 = undefined;
+    if (lib.services.Control.request(allocator, "STOP", &response_buf)) |n| {
+        if (std.mem.indexOf(u8, response_buf[0..n], "\"ok\":true") != null) {
+            try stdout.writeStreamingAll(zio(), "meshguard stop requested via control socket.\n");
+            return;
+        }
+        try writeFormatted(stderr, "error: daemon rejected stop request: {s}", .{response_buf[0..n]});
         std.process.exit(1);
-    } else {
-        lib.wireguard.Config.teardown(lib.wireguard.Config.DEFAULT_IFNAME) catch |err| {
-            switch (err) {
-                error.SocketCreateFailed => try stderr.writeStreamingAll(zio(), "error: permission denied. Run with sudo.\n"),
-                error.NetlinkError => try stderr.writeStreamingAll(zio(), "error: interface mg0 not found.\n"),
-                else => try writeFormatted(stderr, "error: {s}\n", .{@errorName(err)}),
-            }
+    } else |_| {
+        if (comptime @import("builtin").os.tag != .linux) {
+            try stderr.writeStreamingAll(zio(), "meshguard is not running (control socket unavailable).\n");
             std.process.exit(1);
-        };
+        }
     }
+
+    lib.wireguard.Config.teardown(lib.wireguard.Config.DEFAULT_IFNAME) catch |err| {
+        switch (err) {
+            error.SocketCreateFailed => try stderr.writeStreamingAll(zio(), "error: permission denied. Run with sudo.\n"),
+            error.NetlinkError => try stderr.writeStreamingAll(zio(), "error: interface mg0 not found.\n"),
+            else => try writeFormatted(stderr, "error: {s}\n", .{@errorName(err)}),
+        }
+        std.process.exit(1);
+    };
 
     try stdout.writeStreamingAll(zio(), "meshguard stopped. Interface mg0 removed.\n");
 }
@@ -3549,9 +3559,15 @@ fn cmdStatus(allocator: std.mem.Allocator) !void {
     const stdout = getStdOut();
     const stderr = getStdErr();
 
-    if (comptime @import("builtin").os.tag != .linux) {
-        try stderr.writeStreamingAll(zio(), "error: 'meshguard status' is only supported on Linux (requires netlink)\n");
-        std.process.exit(1);
+    var response_buf: [4096]u8 = undefined;
+    if (lib.services.Control.request(allocator, "STATUS", &response_buf)) |n| {
+        try printControlStatus(allocator, stdout, response_buf[0..n]);
+        return;
+    } else |_| {
+        if (comptime @import("builtin").os.tag != .linux) {
+            try stderr.writeStreamingAll(zio(), "meshguard is not running (control socket unavailable).\n");
+            std.process.exit(1);
+        }
     }
 
     const Netlink = lib.wireguard.Netlink;
@@ -3731,6 +3747,62 @@ fn cmdStatus(allocator: std.mem.Allocator) !void {
             rx.whole, rx.frac, rx.unit, tx.whole, tx.frac, tx.unit,
         });
     }
+}
+
+fn jsonStringField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = obj.get(key) orelse return null;
+    return switch (value) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+fn jsonIntField(obj: std.json.ObjectMap, key: []const u8) ?i64 {
+    const value = obj.get(key) orelse return null;
+    return switch (value) {
+        .integer => |i| i,
+        else => null,
+    };
+}
+
+fn printControlStatus(allocator: std.mem.Allocator, stdout: std.Io.File, response: []const u8) !void {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, response, .{}) catch {
+        try stdout.writeStreamingAll(zio(), "meshguard is running.\n");
+        try writeFormatted(stdout, "  control response: {s}", .{response});
+        return;
+    };
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => {
+            try stdout.writeStreamingAll(zio(), "meshguard is running.\n");
+            try writeFormatted(stdout, "  control response: {s}", .{response});
+            return;
+        },
+    };
+
+    try stdout.writeStreamingAll(zio(), "meshguard is running.\n");
+    if (jsonStringField(root, "pubkey")) |pubkey| {
+        if (pubkey.len >= 12) {
+            try writeFormatted(stdout, "  public key: {s}...{s}\n", .{ pubkey[0..8], pubkey[pubkey.len - 4 ..] });
+        } else {
+            try writeFormatted(stdout, "  public key: {s}\n", .{pubkey});
+        }
+    }
+    if (jsonStringField(root, "mesh_ip")) |mesh_ip| {
+        try writeFormatted(stdout, "  mesh IP: {s}\n", .{mesh_ip});
+    }
+
+    if (root.get("peers")) |peers_value| switch (peers_value) {
+        .object => |peers| {
+            const alive = jsonIntField(peers, "alive") orelse 0;
+            const suspected = jsonIntField(peers, "suspected") orelse 0;
+            const dead = jsonIntField(peers, "dead") orelse 0;
+            try writeFormatted(stdout, "  peers: {d} alive, {d} suspected, {d} dead\n", .{ alive, suspected, dead });
+        },
+        else => {},
+    };
 }
 
 const FormattedBytes = struct {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3536,11 +3536,17 @@ fn cmdDown(allocator: std.mem.Allocator) !void {
         }
         try writeFormatted(stderr, "error: daemon rejected stop request: {s}", .{response_buf[0..n]});
         std.process.exit(1);
-    } else |_| {
-        if (comptime @import("builtin").os.tag != .linux) {
-            try stderr.writeStreamingAll(zio(), "meshguard is not running (control socket unavailable).\n");
+    } else |err| switch (err) {
+        error.ControlSocketUnavailable => {
+            if (comptime @import("builtin").os.tag != .linux) {
+                try stderr.writeStreamingAll(zio(), "meshguard is not running (control socket unavailable).\n");
+                std.process.exit(1);
+            }
+        },
+        else => {
+            try writeFormatted(stderr, "error: control socket stop failed: {s}\n", .{@errorName(err)});
             std.process.exit(1);
-        }
+        },
     }
 
     lib.wireguard.Config.teardown(lib.wireguard.Config.DEFAULT_IFNAME) catch |err| {
@@ -3563,11 +3569,17 @@ fn cmdStatus(allocator: std.mem.Allocator) !void {
     if (lib.services.Control.request(allocator, "STATUS", &response_buf)) |n| {
         try printControlStatus(allocator, stdout, response_buf[0..n]);
         return;
-    } else |_| {
-        if (comptime @import("builtin").os.tag != .linux) {
-            try stderr.writeStreamingAll(zio(), "meshguard is not running (control socket unavailable).\n");
+    } else |err| switch (err) {
+        error.ControlSocketUnavailable => {
+            if (comptime @import("builtin").os.tag != .linux) {
+                try stderr.writeStreamingAll(zio(), "meshguard is not running (control socket unavailable).\n");
+                std.process.exit(1);
+            }
+        },
+        else => {
+            try writeFormatted(stderr, "error: control socket status failed: {s}\n", .{@errorName(err)});
             std.process.exit(1);
-        }
+        },
     }
 
     const Netlink = lib.wireguard.Netlink;
@@ -3765,10 +3777,17 @@ fn jsonIntField(obj: std.json.ObjectMap, key: []const u8) ?i64 {
     };
 }
 
+fn printRawControlResponse(stdout: std.Io.File, response: []const u8) !void {
+    try writeFormatted(stdout, "  control response: {s}", .{response});
+    if (response.len == 0 or response[response.len - 1] != '\n') {
+        try stdout.writeStreamingAll(zio(), "\n");
+    }
+}
+
 fn printControlStatus(allocator: std.mem.Allocator, stdout: std.Io.File, response: []const u8) !void {
     var parsed = std.json.parseFromSlice(std.json.Value, allocator, response, .{}) catch {
         try stdout.writeStreamingAll(zio(), "meshguard is running.\n");
-        try writeFormatted(stdout, "  control response: {s}", .{response});
+        try printRawControlResponse(stdout, response);
         return;
     };
     defer parsed.deinit();
@@ -3777,7 +3796,7 @@ fn printControlStatus(allocator: std.mem.Allocator, stdout: std.Io.File, respons
         .object => |obj| obj,
         else => {
             try stdout.writeStreamingAll(zio(), "meshguard is running.\n");
-            try writeFormatted(stdout, "  control response: {s}", .{response});
+            try printRawControlResponse(stdout, response);
             return;
         },
     };

--- a/src/services/control.zig
+++ b/src/services/control.zig
@@ -14,10 +14,15 @@ const std = @import("std");
 const builtin = @import("builtin");
 const is_windows = builtin.os.tag == .windows;
 const is_linux = builtin.os.tag == .linux;
+const has_getpeereid = builtin.os.tag == .macos or builtin.os.tag == .freebsd;
 const posix = std.posix;
 const Config = @import("../config.zig").Config;
 const Membership = @import("../discovery/membership.zig");
 const Ip = @import("../wireguard/ip.zig");
+
+const unix_peer = if (has_getpeereid) struct {
+    extern "c" fn getpeereid(socket: c_int, euid: *std.c.uid_t, egid: *std.c.gid_t) c_int;
+} else struct {};
 
 fn linuxSocket(domain: u32, sock_type: u32, protocol: u32) !std.posix.socket_t {
     const fd = std.c.socket(@intCast(domain), @intCast(sock_type), @intCast(protocol));
@@ -264,19 +269,20 @@ pub const ControlSocket = struct {
         if (comptime !is_windows) return false;
 
         const pipe = self.server orelse return false;
+        const error_pipe_connected = @as(win.windows.Win32Error, @enumFromInt(535));
+        const error_no_data = @as(win.windows.Win32Error, @enumFromInt(232));
+        const error_pipe_listening = @as(win.windows.Win32Error, @enumFromInt(536));
 
         // Try to connect a client (non-blocking)
         const connected = win.ConnectNamedPipe(pipe, null);
         if (connected == @as(win.BOOL, @enumFromInt(0))) {
             const err = win.GetLastError();
-            // ERROR_PIPE_CONNECTED (535) means client already connected
-            if (err != @as(win.windows.Win32Error, @enumFromInt(535)) and
-                err != @as(win.windows.Win32Error, @enumFromInt(232)) and // ERROR_NO_DATA
-                err != @as(win.windows.Win32Error, @enumFromInt(536))) // ERROR_PIPE_LISTENING
-            {
+            if (err == error_no_data) {
+                _ = win.DisconnectNamedPipe(pipe);
                 return false;
             }
-            if (err == @as(win.windows.Win32Error, @enumFromInt(536))) return false;
+            if (err != error_pipe_connected and err != error_pipe_listening) return false;
+            if (err == error_pipe_listening) return false;
         }
 
         // Read command from pipe
@@ -295,7 +301,7 @@ pub const ControlSocket = struct {
 
         // Generate response
         var resp_buf: [8192]u8 = undefined;
-        const resp_len = self.formatCommandResponse(cmd, &resp_buf);
+        const resp_len = self.formatCommandResponse(cmd, &resp_buf, true);
 
         // Write response
         if (resp_len > 0) {
@@ -316,7 +322,8 @@ pub const ControlSocket = struct {
 
         const cmd = std.mem.trimEnd(u8, buf[0..n], "\r\n \t");
         var resp_buf: [8192]u8 = undefined;
-        const resp_len = self.formatCommandResponse(cmd, &resp_buf);
+        const stop_authorized = std.mem.eql(u8, cmd, "STOP") and stopAuthorizedUnix(client);
+        const resp_len = self.formatCommandResponse(cmd, &resp_buf, stop_authorized);
         if (resp_len > 0) {
             writeSocket(client, resp_buf[0..resp_len]);
         }
@@ -324,7 +331,7 @@ pub const ControlSocket = struct {
 
     // ─── Shared response formatters ───
 
-    fn formatCommandResponse(self: *ControlSocket, cmd: []const u8, buf: *[8192]u8) usize {
+    fn formatCommandResponse(self: *ControlSocket, cmd: []const u8, buf: *[8192]u8, stop_authorized: bool) usize {
         if (std.mem.eql(u8, cmd, "PEERS")) {
             return self.formatPeers(buf);
         }
@@ -332,6 +339,11 @@ pub const ControlSocket = struct {
             return self.formatStatus(buf);
         }
         if (std.mem.eql(u8, cmd, "STOP")) {
+            if (!stop_authorized) {
+                const msg = "{\"ok\":false,\"error\":\"unauthorized\"}\n";
+                @memcpy(buf[0..msg.len], msg);
+                return msg.len;
+            }
             if (self.stop_flag) |flag| {
                 flag.store(false, .release);
                 const msg = "{\"ok\":true,\"stopping\":true}\n";
@@ -435,6 +447,41 @@ pub const ControlSocket = struct {
     }
 };
 
+fn peerUidCanStop(peer_uid: std.c.uid_t, daemon_uid: std.c.uid_t) bool {
+    return peer_uid == 0 or peer_uid == daemon_uid;
+}
+
+fn stopAuthorizedUnix(client: posix.socket_t) bool {
+    if (comptime is_windows) return false;
+
+    if (comptime is_linux) {
+        const LinuxPeerCred = extern struct {
+            pid: std.c.pid_t,
+            uid: std.c.uid_t,
+            gid: std.c.gid_t,
+        };
+
+        var cred: LinuxPeerCred = undefined;
+        var len: std.c.socklen_t = @sizeOf(LinuxPeerCred);
+        if (std.c.getsockopt(client, std.os.linux.SOL.SOCKET, std.os.linux.SO.PEERCRED, &cred, &len) != 0) {
+            return false;
+        }
+        if (len < @sizeOf(LinuxPeerCred)) return false;
+        return peerUidCanStop(cred.uid, std.c.geteuid());
+    }
+
+    if (comptime has_getpeereid) {
+        var uid: std.c.uid_t = undefined;
+        var gid: std.c.gid_t = undefined;
+        if (unix_peer.getpeereid(@intCast(client), &uid, &gid) != 0) {
+            return false;
+        }
+        return peerUidCanStop(uid, std.c.geteuid());
+    }
+
+    return false;
+}
+
 pub fn request(allocator: std.mem.Allocator, command: []const u8, out: []u8) !usize {
     if (command.len == 0 or std.mem.indexOfAny(u8, command, "\r\n") != null) {
         return error.InvalidCommand;
@@ -450,14 +497,20 @@ pub fn request(allocator: std.mem.Allocator, command: []const u8, out: []u8) !us
 fn requestUnixDefault(allocator: std.mem.Allocator, command: []const u8, out: []u8) !usize {
     if (requestUnixPath(DEFAULT_SOCKET_PATH, command, out)) |n| {
         return n;
-    } else |_| {}
+    } else |err| switch (err) {
+        error.ControlSocketUnavailable => {},
+        else => return err,
+    }
 
     const config_dir = Config.defaultConfigDir(allocator) catch return error.ControlSocketUnavailable;
     defer allocator.free(config_dir);
     const fallback_path = try std.fs.path.join(allocator, &.{ config_dir, "meshguard.sock" });
     defer allocator.free(fallback_path);
 
-    return requestUnixPath(fallback_path, command, out) catch error.ControlSocketUnavailable;
+    return requestUnixPath(fallback_path, command, out) catch |err| switch (err) {
+        error.ControlSocketUnavailable => error.ControlSocketUnavailable,
+        else => err,
+    };
 }
 
 fn requestUnixPath(path: []const u8, command: []const u8, out: []u8) !usize {
@@ -483,6 +536,7 @@ fn requestUnixPath(path: []const u8, command: []const u8, out: []u8) !usize {
     }
 
     const n = readSocket(sock, out) catch return error.ReadFailed;
+    if (n == 0) return error.ReadFailed;
     if (n == out.len) return error.ResponseTooLarge;
     return n;
 }
@@ -522,6 +576,7 @@ fn requestWindows(command: []const u8, out: []u8) !usize {
     if (win.ReadFile(handle, @ptrCast(out.ptr), @intCast(out.len), &bytes_read, null) == @as(win.BOOL, @enumFromInt(0))) {
         return error.ReadFailed;
     }
+    if (bytes_read == 0) return error.ReadFailed;
     if (bytes_read == out.len) return error.ResponseTooLarge;
     return @intCast(bytes_read);
 }
@@ -537,9 +592,31 @@ test "control STOP response toggles stop flag" {
     control.setStopFlag(&running);
 
     var buf: [8192]u8 = undefined;
-    const n = control.formatCommandResponse("STOP", &buf);
+    const n = control.formatCommandResponse("STOP", &buf, true);
     try std.testing.expectEqualStrings("{\"ok\":true,\"stopping\":true}\n", buf[0..n]);
     try std.testing.expect(!running.load(.acquire));
+}
+
+test "control STOP rejects unauthorized peers" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    var control = ControlSocket.init(allocator, &membership, [_]u8{0x42} ** 32, .{ 10, 99, 1, 2 }, "test.sock");
+
+    var running = std.atomic.Value(bool).init(true);
+    control.setStopFlag(&running);
+
+    var buf: [8192]u8 = undefined;
+    const n = control.formatCommandResponse("STOP", &buf, false);
+    try std.testing.expectEqualStrings("{\"ok\":false,\"error\":\"unauthorized\"}\n", buf[0..n]);
+    try std.testing.expect(running.load(.acquire));
+}
+
+test "control STOP allows same uid or root" {
+    try std.testing.expect(peerUidCanStop(1000, 1000));
+    try std.testing.expect(peerUidCanStop(0, 1000));
+    try std.testing.expect(!peerUidCanStop(1001, 1000));
 }
 
 test "control STATUS response includes peer counts" {
@@ -550,7 +627,7 @@ test "control STATUS response includes peer counts" {
     var control = ControlSocket.init(allocator, &membership, [_]u8{0x24} ** 32, .{ 10, 99, 3, 4 }, "test.sock");
 
     var buf: [8192]u8 = undefined;
-    const n = control.formatCommandResponse("STATUS", &buf);
+    const n = control.formatCommandResponse("STATUS", &buf, false);
     try std.testing.expect(std.mem.indexOf(u8, buf[0..n], "\"running\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf[0..n], "\"mesh_ip\":\"10.99.3.4\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf[0..n], "\"alive\":0") != null);

--- a/src/services/control.zig
+++ b/src/services/control.zig
@@ -8,6 +8,7 @@
 //! Commands:
 //!   PEERS\n     → JSON array of alive peers with mesh IPs
 //!   STATUS\n    → JSON object with daemon status summary
+//!   STOP\n      → request graceful daemon shutdown
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -79,6 +80,14 @@ fn writeSocket(fd: posix.socket_t, data: []const u8) void {
     _ = std.c.write(fd, data.ptr, data.len);
 }
 
+fn readSocket(fd: posix.socket_t, out: []u8) !usize {
+    const n = std.c.read(fd, out.ptr, out.len);
+    return switch (std.posix.errno(n)) {
+        .SUCCESS => @intCast(n),
+        else => |err| std.posix.unexpectedErrno(err),
+    };
+}
+
 // ─── Windows-only imports ───
 const win = if (is_windows) struct {
     const windows = std.os.windows;
@@ -97,6 +106,8 @@ const win = if (is_windows) struct {
     extern "kernel32" fn ReadFile(hFile: HANDLE, lpBuffer: ?*anyopaque, nNumberOfBytesToRead: DWORD, lpNumberOfBytesRead: ?*DWORD, lpOverlapped: ?*anyopaque) callconv(.winapi) BOOL;
     extern "kernel32" fn WriteFile(hFile: HANDLE, lpBuffer: ?*const anyopaque, nNumberOfBytesToWrite: DWORD, lpNumberOfBytesWritten: ?*DWORD, lpOverlapped: ?*anyopaque) callconv(.winapi) BOOL;
     extern "kernel32" fn FlushFileBuffers(hFile: HANDLE) callconv(.winapi) BOOL;
+    extern "kernel32" fn CreateFileW(lpFileName: LPCWSTR, dwDesiredAccess: DWORD, dwShareMode: DWORD, lpSecurityAttributes: ?*anyopaque, dwCreationDisposition: DWORD, dwFlagsAndAttributes: DWORD, hTemplateFile: ?HANDLE) callconv(.winapi) HANDLE;
+    extern "kernel32" fn WaitNamedPipeW(lpNamedPipeName: LPCWSTR, nTimeOut: DWORD) callconv(.winapi) BOOL;
 } else struct {};
 
 pub const DEFAULT_SOCKET_PATH = if (is_windows) "\\\\.\\pipe\\meshguard" else "/run/meshguard/meshguard.sock";
@@ -110,6 +121,7 @@ pub const ControlSocket = struct {
     membership: *Membership.MembershipTable,
     our_pubkey: [32]u8,
     our_mesh_ip: [4]u8,
+    stop_flag: ?*std.atomic.Value(bool),
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -141,6 +153,7 @@ pub const ControlSocket = struct {
                         .membership = membership,
                         .our_pubkey = our_pubkey,
                         .our_mesh_ip = our_mesh_ip,
+                        .stop_flag = null,
                     };
                 }
             }
@@ -153,7 +166,12 @@ pub const ControlSocket = struct {
             .membership = membership,
             .our_pubkey = our_pubkey,
             .our_mesh_ip = our_mesh_ip,
+            .stop_flag = null,
         };
+    }
+
+    pub fn setStopFlag(self: *ControlSocket, stop_flag: *std.atomic.Value(bool)) void {
+        self.stop_flag = stop_flag;
     }
 
     pub fn listen(self: *ControlSocket) !void {
@@ -205,7 +223,7 @@ pub const ControlSocket = struct {
         const pipe_handle = win.CreateNamedPipeW(
             pipe_name,
             0x00000003 | 0x00080000, // PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE
-            0x00000000 | 0x00000000, // PIPE_TYPE_BYTE | PIPE_READMODE_BYTE
+            0x00000000 | 0x00000000 | 0x00000001, // PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_NOWAIT
             1, // max instances
             4096, // out buffer
             4096, // in buffer
@@ -253,10 +271,12 @@ pub const ControlSocket = struct {
             const err = win.GetLastError();
             // ERROR_PIPE_CONNECTED (535) means client already connected
             if (err != @as(win.windows.Win32Error, @enumFromInt(535)) and
-                err != @as(win.windows.Win32Error, @enumFromInt(232)))
-            { // ERROR_NO_DATA (232)
+                err != @as(win.windows.Win32Error, @enumFromInt(232)) and // ERROR_NO_DATA
+                err != @as(win.windows.Win32Error, @enumFromInt(536))) // ERROR_PIPE_LISTENING
+            {
                 return false;
             }
+            if (err == @as(win.windows.Win32Error, @enumFromInt(536))) return false;
         }
 
         // Read command from pipe
@@ -264,6 +284,9 @@ pub const ControlSocket = struct {
         var bytes_read: win.DWORD = 0;
         const read_ok = win.ReadFile(pipe, @ptrCast(&buf), buf.len, &bytes_read, null);
         if (read_ok == @as(win.BOOL, @enumFromInt(0)) or bytes_read == 0) {
+            if (win.GetLastError() == @as(win.windows.Win32Error, @enumFromInt(232))) {
+                return false;
+            }
             _ = win.DisconnectNamedPipe(pipe);
             return false;
         }
@@ -272,19 +295,7 @@ pub const ControlSocket = struct {
 
         // Generate response
         var resp_buf: [8192]u8 = undefined;
-        var resp_len: usize = 0;
-
-        if (std.mem.eql(u8, cmd, "PEERS")) {
-            resp_len = self.formatPeers(&resp_buf);
-        } else if (std.mem.eql(u8, cmd, "STATUS")) {
-            var status_buf: [512]u8 = undefined;
-            resp_len = self.formatStatus(&status_buf);
-            if (resp_len > 0) @memcpy(resp_buf[0..resp_len], status_buf[0..resp_len]);
-        } else {
-            const err_msg = "{\"error\":\"unknown command\"}\n";
-            @memcpy(resp_buf[0..err_msg.len], err_msg);
-            resp_len = err_msg.len;
-        }
+        const resp_len = self.formatCommandResponse(cmd, &resp_buf);
 
         // Write response
         if (resp_len > 0) {
@@ -304,25 +315,38 @@ pub const ControlSocket = struct {
         if (n == 0) return;
 
         const cmd = std.mem.trimEnd(u8, buf[0..n], "\r\n \t");
-
-        if (std.mem.eql(u8, cmd, "PEERS")) {
-            var resp_buf: [8192]u8 = undefined;
-            const resp_len = self.formatPeers(&resp_buf);
-            if (resp_len > 0) {
-                writeSocket(client, resp_buf[0..resp_len]);
-            }
-        } else if (std.mem.eql(u8, cmd, "STATUS")) {
-            var resp_buf: [512]u8 = undefined;
-            const resp_len = self.formatStatus(&resp_buf);
-            if (resp_len > 0) {
-                writeSocket(client, resp_buf[0..resp_len]);
-            }
-        } else {
-            writeSocket(client, "{\"error\":\"unknown command\"}\n");
+        var resp_buf: [8192]u8 = undefined;
+        const resp_len = self.formatCommandResponse(cmd, &resp_buf);
+        if (resp_len > 0) {
+            writeSocket(client, resp_buf[0..resp_len]);
         }
     }
 
     // ─── Shared response formatters ───
+
+    fn formatCommandResponse(self: *ControlSocket, cmd: []const u8, buf: *[8192]u8) usize {
+        if (std.mem.eql(u8, cmd, "PEERS")) {
+            return self.formatPeers(buf);
+        }
+        if (std.mem.eql(u8, cmd, "STATUS")) {
+            return self.formatStatus(buf);
+        }
+        if (std.mem.eql(u8, cmd, "STOP")) {
+            if (self.stop_flag) |flag| {
+                flag.store(false, .release);
+                const msg = "{\"ok\":true,\"stopping\":true}\n";
+                @memcpy(buf[0..msg.len], msg);
+                return msg.len;
+            }
+            const msg = "{\"ok\":false,\"error\":\"stop not supported\"}\n";
+            @memcpy(buf[0..msg.len], msg);
+            return msg.len;
+        }
+
+        const err_msg = "{\"error\":\"unknown command\"}\n";
+        @memcpy(buf[0..err_msg.len], err_msg);
+        return err_msg.len;
+    }
 
     fn formatPeers(self: *ControlSocket, buf: *[8192]u8) usize {
         var pos: usize = 0;
@@ -361,7 +385,7 @@ pub const ControlSocket = struct {
         return pos;
     }
 
-    fn formatStatus(self: *ControlSocket, buf: *[512]u8) usize {
+    fn formatStatus(self: *ControlSocket, buf: []u8) usize {
         var alive: usize = 0;
         var suspected: usize = 0;
         var dead: usize = 0;
@@ -410,3 +434,124 @@ pub const ControlSocket = struct {
         }
     }
 };
+
+pub fn request(allocator: std.mem.Allocator, command: []const u8, out: []u8) !usize {
+    if (command.len == 0 or std.mem.indexOfAny(u8, command, "\r\n") != null) {
+        return error.InvalidCommand;
+    }
+
+    if (comptime is_windows) {
+        return requestWindows(command, out);
+    } else {
+        return requestUnixDefault(allocator, command, out);
+    }
+}
+
+fn requestUnixDefault(allocator: std.mem.Allocator, command: []const u8, out: []u8) !usize {
+    if (requestUnixPath(DEFAULT_SOCKET_PATH, command, out)) |n| {
+        return n;
+    } else |_| {}
+
+    const config_dir = Config.defaultConfigDir(allocator) catch return error.ControlSocketUnavailable;
+    defer allocator.free(config_dir);
+    const fallback_path = try std.fs.path.join(allocator, &.{ config_dir, "meshguard.sock" });
+    defer allocator.free(fallback_path);
+
+    return requestUnixPath(fallback_path, command, out) catch error.ControlSocketUnavailable;
+}
+
+fn requestUnixPath(path: []const u8, command: []const u8, out: []u8) !usize {
+    const addr = initUnixSocketAddress(path) catch return error.ControlSocketUnavailable;
+    const sock = try linuxSocket(posix.AF.UNIX, posix.SOCK.STREAM, 0);
+    defer closeSocket(sock);
+
+    if (std.c.connect(sock, @ptrCast(&addr.addr), addr.len) != 0) {
+        return error.ControlSocketUnavailable;
+    }
+
+    writeSocket(sock, command);
+    writeSocket(sock, "\n");
+
+    var fds = [_]posix.pollfd{.{
+        .fd = sock,
+        .events = posix.POLL.IN,
+        .revents = 0,
+    }};
+    const ready = posix.poll(&fds, 1000) catch return error.ControlSocketUnavailable;
+    if (ready == 0 or (fds[0].revents & posix.POLL.IN) == 0) {
+        return error.ControlSocketUnavailable;
+    }
+
+    const n = readSocket(sock, out) catch return error.ReadFailed;
+    if (n == out.len) return error.ResponseTooLarge;
+    return n;
+}
+
+fn requestWindows(command: []const u8, out: []u8) !usize {
+    if (comptime !is_windows) unreachable;
+
+    const pipe_name = std.unicode.utf8ToUtf16LeStringLiteral("\\\\.\\pipe\\meshguard");
+    const waited = win.WaitNamedPipeW(pipe_name, 1000);
+    if (waited == @as(win.BOOL, @enumFromInt(0))) {
+        return error.ControlSocketUnavailable;
+    }
+
+    const handle = win.CreateFileW(
+        pipe_name,
+        0x80000000 | 0x40000000, // GENERIC_READ | GENERIC_WRITE
+        0,
+        null,
+        3, // OPEN_EXISTING
+        0x00000080, // FILE_ATTRIBUTE_NORMAL
+        null,
+    );
+    if (handle == win.windows.INVALID_HANDLE_VALUE) {
+        return error.ControlSocketUnavailable;
+    }
+    defer _ = win.CloseHandle(handle);
+
+    var bytes_written: win.DWORD = 0;
+    if (win.WriteFile(handle, @ptrCast(command.ptr), @intCast(command.len), &bytes_written, null) == @as(win.BOOL, @enumFromInt(0))) {
+        return error.WriteFailed;
+    }
+    if (win.WriteFile(handle, @ptrCast("\n".ptr), 1, &bytes_written, null) == @as(win.BOOL, @enumFromInt(0))) {
+        return error.WriteFailed;
+    }
+
+    var bytes_read: win.DWORD = 0;
+    if (win.ReadFile(handle, @ptrCast(out.ptr), @intCast(out.len), &bytes_read, null) == @as(win.BOOL, @enumFromInt(0))) {
+        return error.ReadFailed;
+    }
+    if (bytes_read == out.len) return error.ResponseTooLarge;
+    return @intCast(bytes_read);
+}
+
+test "control STOP response toggles stop flag" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    var control = ControlSocket.init(allocator, &membership, [_]u8{0x42} ** 32, .{ 10, 99, 1, 2 }, "test.sock");
+
+    var running = std.atomic.Value(bool).init(true);
+    control.setStopFlag(&running);
+
+    var buf: [8192]u8 = undefined;
+    const n = control.formatCommandResponse("STOP", &buf);
+    try std.testing.expectEqualStrings("{\"ok\":true,\"stopping\":true}\n", buf[0..n]);
+    try std.testing.expect(!running.load(.acquire));
+}
+
+test "control STATUS response includes peer counts" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    var control = ControlSocket.init(allocator, &membership, [_]u8{0x24} ** 32, .{ 10, 99, 3, 4 }, "test.sock");
+
+    var buf: [8192]u8 = undefined;
+    const n = control.formatCommandResponse("STATUS", &buf);
+    try std.testing.expect(std.mem.indexOf(u8, buf[0..n], "\"running\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf[0..n], "\"mesh_ip\":\"10.99.3.4\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf[0..n], "\"alive\":0") != null);
+}


### PR DESCRIPTION
## Summary

- Route `meshguard status` through the userspace control socket before falling back to Linux netlink/kernel WireGuard status.
- Route `meshguard down` through a new `STOP` control command before falling back to Linux RTNETLINK teardown.
- Make Windows named-pipe polling nonblocking and add a short Unix control-socket response timeout.
- Update CLI and platform docs to remove stale Linux-only caveats for userspace daemon status/down.

## Validation

- `zig build test --summary all` passed, 90/90 tests.
- `zig build --summary all` passed, 7/7 steps.
- `git diff --check` passed.
- Windows smoke: temporary gossip-only daemon returned `meshguard status`, then stopped via `meshguard down` with daemon exit code 0.
- Windows no-daemon smoke: `meshguard status` reports control socket unavailable.

Closes #125