### PR TITLE
fix: use configured STUN hostnames

### DIFF
--- a/docs/concepts/nat-traversal.md
+++ b/docs/concepts/nat-traversal.md
@@ -29,16 +29,17 @@ The discovered public endpoint is then shared via gossip, so other peers know ho
 
 ### STUN Servers
 
-The runtime STUN client currently uses embedded IPv4 endpoints in
-`nat/stun.zig` for these services:
+The runtime STUN client resolves the configured `host:port` entries from
+`Config.stun_servers`:
 
-| Server                | IP               | Port  |
-| --------------------- | ---------------- | ----- |
-| `stun.l.google.com`   | `74.125.250.129` | 19302 |
-| `stun.cloudflare.com` | `104.18.32.7`    | 3478  |
+| Server                | Port  |
+| --------------------- | ----- |
+| `stun.l.google.com`   | 19302 |
+| `stun.cloudflare.com` | 3478  |
 
-The higher-level `Config` struct also records the hostname form. If either
-provider changes addresses, update `nat/stun.zig` before cutting a release.
+If no configured server resolves, meshguard falls back to deterministic IPv4
+endpoints for the same services so environments without working DNS still have a
+stable startup path.
 
 ## Tier 2: UDP Hole Punching
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -108,13 +108,14 @@ $MESHGUARD_CONFIG_DIR/
 
 ## STUN Servers
 
-meshguard uses built-in STUN servers for public endpoint discovery:
+meshguard resolves configured STUN server hostnames at runtime for public endpoint discovery:
 
 | Server                | Port  |
 | --------------------- | ----- |
 | `stun.l.google.com`   | 19302 |
 | `stun.cloudflare.com` | 3478  |
 
-The default `Config` stores these as `host:port` strings. The current runtime
-path calls `nat/stun.zig`'s embedded IPv4 defaults for these services, so update
-that module if the providers change addresses before a release.
+The default `Config` stores these as `host:port` strings and the runtime STUN
+client consumes that list. If no configured server can be resolved, meshguard
+falls back to deterministic IPv4 endpoints for the same services so startup can
+still proceed in DNS-constrained environments.

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -82,6 +82,7 @@ test {
     _ = wireguard.Crypto;
     _ = wireguard.Ip;
     _ = discovery.Swim;
+    @import("std").testing.refAllDecls(nat.Stun);
     if (is_linux) {
         _ = wireguard.Config;
         _ = wireguard.Netlink;

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -82,6 +82,7 @@ test {
     _ = wireguard.Crypto;
     _ = wireguard.Ip;
     _ = discovery.Swim;
+    @import("std").testing.refAllDecls(net.Dns);
     @import("std").testing.refAllDecls(nat.Stun);
     if (is_linux) {
         _ = wireguard.Config;

--- a/src/main.zig
+++ b/src/main.zig
@@ -105,6 +105,11 @@ fn childExitedSuccessfully(term: std.process.Child.Term) bool {
     return childExitCode(term) == 0;
 }
 
+fn configuredStunServers(out: []lib.nat.Stun.StunServer) []const lib.nat.Stun.StunServer {
+    const cfg = Config{};
+    return lib.nat.Stun.configuredOrDefault(cfg.stun_servers, out);
+}
+
 pub fn main(init: std.process.Init) !void {
     runtime_io = init.io;
     const allocator = init.gpa;
@@ -998,8 +1003,10 @@ fn cmdUp(allocator: std.mem.Allocator, extra_args: []const []const u8) !void {
     } else {
         // Run STUN to discover our public endpoint and NAT type
         const Stun = lib.nat.Stun;
+        var stun_server_buf: [Stun.MAX_CONFIGURED_STUN_SERVERS]Stun.StunServer = undefined;
+        const stun_servers = configuredStunServers(&stun_server_buf);
         try stdout.writeStreamingAll(zio(), "  discovering public endpoint (STUN)...\n");
-        const stun_result = Stun.discover(&gossip_socket, gossip_port, &Stun.DEFAULT_STUN_SERVERS);
+        const stun_result = Stun.discover(&gossip_socket, gossip_port, stun_servers);
         swim.setPublicEndpoint(
             if (stun_result.nat_type != .unknown) messages.Endpoint{ .addr = stun_result.external.addr, .port = stun_result.external.port } else null,
             stun_result.nat_type,
@@ -1398,8 +1405,10 @@ fn cmdConnect(allocator: std.mem.Allocator, extra_args: []const []const u8) !voi
     defer socket.close();
 
     // STUN discovery
+    var stun_server_buf: [Stun.MAX_CONFIGURED_STUN_SERVERS]Stun.StunServer = undefined;
+    const stun_servers = configuredStunServers(&stun_server_buf);
     try stdout.writeStreamingAll(zio(), "  discovering public endpoint (STUN)...\n");
-    const stun_result = Stun.discover(&socket, gossip_port, &Stun.DEFAULT_STUN_SERVERS);
+    const stun_result = Stun.discover(&socket, gossip_port, stun_servers);
     if (stun_result.nat_type == .unknown) {
         try stderr.writeStreamingAll(zio(), "error: STUN failed — could not determine public endpoint\n");
         try stderr.writeStreamingAll(zio(), "  hint: check internet connectivity or firewall\n");
@@ -1425,7 +1434,7 @@ fn cmdConnect(allocator: std.mem.Allocator, extra_args: []const []const u8) !voi
     const ntp_time = CoordinatedPunch.currentTimeSecs();
 
     // Pick STUN server used (for token)
-    const stun_server = Stun.DEFAULT_STUN_SERVERS[0];
+    const stun_server = stun_servers[0];
 
     switch (mode) {
         .generate => {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1434,7 +1434,7 @@ fn cmdConnect(allocator: std.mem.Allocator, extra_args: []const []const u8) !voi
     const ntp_time = CoordinatedPunch.currentTimeSecs();
 
     // Pick STUN server used (for token)
-    const stun_server = stun_servers[0];
+    const stun_server = stun_result.server orelse stun_servers[0];
 
     switch (mode) {
         .generate => {

--- a/src/nat/stun.zig
+++ b/src/nat/stun.zig
@@ -11,6 +11,7 @@
 //!     XOR-MAPPED-ADDRESS (0x0020): [2B reserved][1B family][2B xport][4B xaddr]
 
 const std = @import("std");
+const Dns = @import("../net/dns.zig");
 const Udp = @import("../net/udp.zig");
 const messages = @import("../protocol/messages.zig");
 
@@ -47,16 +48,72 @@ pub const StunResult = struct {
     nat_type: NatType,
 };
 
-/// Default STUN servers to try.
+/// Numeric fallback STUN servers used when configured hostnames cannot be resolved.
 pub const DEFAULT_STUN_SERVERS = [_]StunServer{
     .{ .host = .{ 74, 125, 250, 129 }, .port = 19302 }, // stun.l.google.com
     .{ .host = .{ 104, 18, 32, 7 }, .port = 3478 }, // stun.cloudflare.com
 };
 
+pub const MAX_CONFIGURED_STUN_SERVERS: usize = 8;
+
 pub const StunServer = struct {
     host: [4]u8,
     port: u16,
 };
+
+pub const StunServerSpec = struct {
+    host: []const u8,
+    port: u16,
+};
+
+pub fn parseServerSpec(spec: []const u8) ?StunServerSpec {
+    const trimmed = std.mem.trim(u8, spec, " \t\r\n");
+    const colon_idx = std.mem.lastIndexOfScalar(u8, trimmed, ':') orelse return null;
+    const host = std.mem.trim(u8, trimmed[0..colon_idx], " \t");
+    const port_str = std.mem.trim(u8, trimmed[colon_idx + 1 ..], " \t");
+    if (host.len == 0 or port_str.len == 0) return null;
+
+    const port = std.fmt.parseInt(u16, port_str, 10) catch return null;
+    if (port == 0) return null;
+    return .{ .host = host, .port = port };
+}
+
+pub fn resolveServerSpec(spec: []const u8) ?StunServer {
+    const parsed = parseServerSpec(spec) orelse return null;
+    const host = parseIpv4(parsed.host) orelse Dns.resolveA(parsed.host) orelse return null;
+    return .{ .host = host, .port = parsed.port };
+}
+
+pub fn resolveConfiguredServers(configured: []const []const u8, out: []StunServer) []const StunServer {
+    var count: usize = 0;
+    for (configured) |spec| {
+        if (count >= out.len) break;
+        if (resolveServerSpec(spec)) |server| {
+            out[count] = server;
+            count += 1;
+        }
+    }
+    return out[0..count];
+}
+
+pub fn configuredOrDefault(configured: []const []const u8, out: []StunServer) []const StunServer {
+    const resolved = resolveConfiguredServers(configured, out);
+    if (resolved.len > 0) return resolved;
+    return &DEFAULT_STUN_SERVERS;
+}
+
+fn parseIpv4(s: []const u8) ?[4]u8 {
+    var addr: [4]u8 = undefined;
+    var octets = std.mem.splitScalar(u8, s, '.');
+    var i: usize = 0;
+    while (octets.next()) |octet| {
+        if (i >= 4 or octet.len == 0) return null;
+        addr[i] = std.fmt.parseInt(u8, octet, 10) catch return null;
+        i += 1;
+    }
+    if (i != 4) return null;
+    return addr;
+}
 
 // ─── Encoding ───
 
@@ -311,4 +368,39 @@ test "decode rejects wrong txn_id" {
     @memcpy(resp[8..20], &wrong_txn);
 
     try std.testing.expectError(error.TransactionIdMismatch, decodeBindingResponse(&resp, txn_id));
+}
+
+test "parse STUN server specs" {
+    const parsed = parseServerSpec(" stun.example.com:3478 ").?;
+    try std.testing.expectEqualStrings("stun.example.com", parsed.host);
+    try std.testing.expectEqual(@as(u16, 3478), parsed.port);
+
+    try std.testing.expect(parseServerSpec("stun.example.com") == null);
+    try std.testing.expect(parseServerSpec(":3478") == null);
+    try std.testing.expect(parseServerSpec("stun.example.com:0") == null);
+    try std.testing.expect(parseServerSpec("stun.example.com:not-a-port") == null);
+}
+
+test "resolve configured STUN server IP literals" {
+    var out: [MAX_CONFIGURED_STUN_SERVERS]StunServer = undefined;
+    const resolved = resolveConfiguredServers(&.{
+        "203.0.113.10:3478",
+        "bad-entry",
+        "198.51.100.20:19302",
+    }, &out);
+
+    try std.testing.expectEqual(@as(usize, 2), resolved.len);
+    try std.testing.expectEqual([4]u8{ 203, 0, 113, 10 }, resolved[0].host);
+    try std.testing.expectEqual(@as(u16, 3478), resolved[0].port);
+    try std.testing.expectEqual([4]u8{ 198, 51, 100, 20 }, resolved[1].host);
+    try std.testing.expectEqual(@as(u16, 19302), resolved[1].port);
+}
+
+test "configured STUN servers fall back when none resolve" {
+    var out: [MAX_CONFIGURED_STUN_SERVERS]StunServer = undefined;
+    const resolved = configuredOrDefault(&.{ "bad-entry", "also-bad" }, &out);
+
+    try std.testing.expectEqual(@as(usize, DEFAULT_STUN_SERVERS.len), resolved.len);
+    try std.testing.expectEqual(DEFAULT_STUN_SERVERS[0].host, resolved[0].host);
+    try std.testing.expectEqual(DEFAULT_STUN_SERVERS[0].port, resolved[0].port);
 }

--- a/src/nat/stun.zig
+++ b/src/nat/stun.zig
@@ -46,6 +46,7 @@ pub const NatType = messages.NatType;
 pub const StunResult = struct {
     external: ExternalAddress,
     nat_type: NatType,
+    server: ?StunServer = null,
 };
 
 /// Numeric fallback STUN servers used when configured hostnames cannot be resolved.
@@ -80,7 +81,10 @@ pub fn parseServerSpec(spec: []const u8) ?StunServerSpec {
 
 pub fn resolveServerSpec(spec: []const u8) ?StunServer {
     const parsed = parseServerSpec(spec) orelse return null;
-    const host = parseIpv4(parsed.host) orelse Dns.resolveA(parsed.host) orelse return null;
+    const host = parseIpv4(parsed.host) orelse blk: {
+        if (!shouldResolveHostname(parsed.host)) return null;
+        break :blk Dns.resolveA(parsed.host) orelse return null;
+    };
     return .{ .host = host, .port = parsed.port };
 }
 
@@ -113,6 +117,25 @@ fn parseIpv4(s: []const u8) ?[4]u8 {
     }
     if (i != 4) return null;
     return addr;
+}
+
+fn shouldResolveHostname(host: []const u8) bool {
+    if (std.mem.indexOfScalar(u8, host, ':') != null) return false;
+    if (looksLikeIpv4Literal(host)) return false;
+    return true;
+}
+
+fn looksLikeIpv4Literal(host: []const u8) bool {
+    if (host.len == 0) return false;
+    var saw_dot = false;
+    for (host) |ch| {
+        switch (ch) {
+            '0'...'9' => {},
+            '.' => saw_dot = true,
+            else => return false,
+        }
+    }
+    return saw_dot;
 }
 
 // ─── Encoding ───
@@ -259,13 +282,14 @@ pub fn discover(socket: *Udp.UdpSocket, local_port: u16, servers: []const StunSe
         else
             .cone; // different port → some NAT present
 
-        return .{ .external = ext, .nat_type = nat_type };
+        return .{ .external = ext, .nat_type = nat_type, .server = server };
     }
 
     // All servers failed
     return .{
         .external = .{ .addr = .{ 0, 0, 0, 0 }, .port = 0 },
         .nat_type = .unknown,
+        .server = null,
     };
 }
 
@@ -379,6 +403,12 @@ test "parse STUN server specs" {
     try std.testing.expect(parseServerSpec(":3478") == null);
     try std.testing.expect(parseServerSpec("stun.example.com:0") == null);
     try std.testing.expect(parseServerSpec("stun.example.com:not-a-port") == null);
+}
+
+test "reject malformed STUN host specs before DNS" {
+    try std.testing.expect(resolveServerSpec("1.2.3.999:3478") == null);
+    try std.testing.expect(resolveServerSpec("1.2.3.4.5:3478") == null);
+    try std.testing.expect(resolveServerSpec("[2001:db8::1]:3478") == null);
 }
 
 test "resolve configured STUN server IP literals" {

--- a/src/net/dns.zig
+++ b/src/net/dns.zig
@@ -50,6 +50,14 @@ const CLASS_IN: u16 = 1;
 const HEADER_LEN: usize = 12;
 const MAX_RESPONSE: usize = 512; // Standard DNS UDP max
 
+fn ipv4SockaddrAddr(addr: [4]u8) u32 {
+    const host_order = (@as(u32, addr[0]) << 24) |
+        (@as(u32, addr[1]) << 16) |
+        (@as(u32, addr[2]) << 8) |
+        @as(u32, addr[3]);
+    return std.mem.nativeToBig(u32, host_order);
+}
+
 // ─── DNS Header ───
 
 const DnsHeader = struct {
@@ -196,7 +204,7 @@ pub fn queryMDNS(allocator: std.mem.Allocator, service_name: []const u8) ![][]co
     const mdns_addr = posix.sockaddr.in{
         .family = posix.AF.INET,
         .port = std.mem.nativeToBig(u16, MDNS_PORT),
-        .addr = std.mem.nativeToBig(u32, @as(u32, @bitCast(MDNS_ADDR))),
+        .addr = ipv4SockaddrAddr(MDNS_ADDR),
         .zero = .{ 0, 0, 0, 0, 0, 0, 0, 0 },
     };
     if (comptime is_linux) {
@@ -504,7 +512,7 @@ fn sendQuery(nameserver: [4]u8, port: u16, query: []const u8) ?QueryResponse {
     const addr = posix.sockaddr.in{
         .family = posix.AF.INET,
         .port = std.mem.nativeToBig(u16, port),
-        .addr = std.mem.nativeToBig(u32, @as(u32, @bitCast(nameserver))),
+        .addr = ipv4SockaddrAddr(nameserver),
         .zero = .{ 0, 0, 0, 0, 0, 0, 0, 0 },
     };
 
@@ -643,6 +651,11 @@ test "responseMatchesQuery rejects spoofed/mismatched responses (H5 regression)"
 
     // Truncated response rejected (no OOB).
     try std.testing.expect(!responseMatchesQuery(buf[0..5], id, domain, TYPE_A));
+}
+
+test "IPv4 sockaddr address preserves octet order" {
+    const raw = ipv4SockaddrAddr(.{ 127, 0, 0, 53 });
+    try std.testing.expectEqual(@as(u32, 0x7f000035), std.mem.bigToNative(u32, raw));
 }
 
 test "parse meshguard TXT" {

--- a/src/net/dns.zig
+++ b/src/net/dns.zig
@@ -71,18 +71,16 @@ const DnsHeader = struct {
 
 // ─── Public API ───
 
-/// Get nameserver IPv4 addresses. On Linux, parses /etc/resolv.conf.
+/// Get nameserver IPv4 addresses. On POSIX, parses /etc/resolv.conf.
 /// On Windows, uses well-known public DNS servers as fallback.
 pub fn getNameservers(buf: *[3][4]u8) usize {
-    if (comptime is_linux) {
-        return getNameserversLinux(buf);
-    } else if (comptime is_windows) {
+    if (comptime is_windows) {
         return getNameserversWindows(buf);
     }
-    return 0;
+    return getNameserversResolvConf(buf);
 }
 
-fn getNameserversLinux(buf: *[3][4]u8) usize {
+fn getNameserversResolvConf(buf: *[3][4]u8) usize {
     const z = zio();
     const file = std.Io.Dir.openFileAbsolute(z, "/etc/resolv.conf", .{}) catch return 0;
     defer file.close(z);


### PR DESCRIPTION
## Summary
- Resolve STUN `host:port` entries from `Config.stun_servers` at runtime instead of using embedded provider IPs first.
- Keep deterministic numeric STUN endpoints as fallback when no configured server resolves.
- Wire `up` and `connect` through the configured STUN selector and update NAT/config docs.

Closes #127

## Validation
- `zig build test --summary all` (103/103 tests passed)
- `zig build --summary all`
- `git diff --check`
- Windows smoke: temp-config `meshguard up --gossip-only --open` without `--announce` discovered a public STUN endpoint, `status` succeeded, and `down` stopped the daemon with exit 0
- `zig build -Dtarget=x86_64-linux-gnu -Dno-sodium=true --summary all`
- `zig build -Dtarget=x86_64-macos -Doptimize=ReleaseFast --summary all`
- `zig build -Dtarget=x86_64-freebsd -Doptimize=ReleaseFast --summary all`