### PR TITLE
fix: add org revocation CLI

### DIFF
--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -42,7 +42,7 @@ meshguard's security model is built on three pillars: **cryptographic identity**
 
 - **Org admins hold signing keys** — treat like root CA keys
 - **Node certificates** — 186 bytes, stored at `~/.config/meshguard/node.cert`
-- **Revocation** — remove individual trust files immediately with `meshguard revoke`, or sign org-scope revocations with `meshguard org-revoke`
+- **Revocation** — remove individual trust files immediately with `meshguard revoke`, or sign issuer-scoped org revocations with `meshguard org-revoke`
 
 ## Attack Surface
 

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -42,7 +42,7 @@ meshguard's security model is built on three pillars: **cryptographic identity**
 
 - **Org admins hold signing keys** — treat like root CA keys
 - **Node certificates** — 186 bytes, stored at `~/.config/meshguard/node.cert`
-- **Revocation** — remove individual trust files immediately; signed org revocation messages are receive-side supported, but a public `org-revoke` CLI is not exposed yet
+- **Revocation** — remove individual trust files immediately with `meshguard revoke`, or sign org-scope revocations with `meshguard org-revoke`
 
 ## Attack Surface
 

--- a/docs/guide/trust-model.md
+++ b/docs/guide/trust-model.md
@@ -129,8 +129,10 @@ verification signs the revoked node key, reason, and Lamport timestamp.
 Org admins revoke an org-signed node with `meshguard org-revoke`. The command
 loads the local org signing key, writes a signed `OrgCertRevoke` message under
 `revoked/`, and `meshguard up` queues the saved revocation for best-effort
-broadcast to known peers. Individual trust files can still be removed locally
-with `meshguard revoke` when a peer was admitted outside org trust.
+broadcast to known peers. Revocations are scoped to the issuing org, so they
+invalidate that org's certificate or vouch for the node without cancelling a
+different trusted org's authority. Individual trust files can still be removed
+locally with `meshguard revoke` when a peer was admitted outside org trust.
 
 ### Org Vouch (External Peers)
 

--- a/docs/guide/trust-model.md
+++ b/docs/guide/trust-model.md
@@ -115,6 +115,9 @@ meshguard trust <org-pubkey> --org --name eosrio
 
 # Vouch for an external standalone node
 meshguard org-vouch <solo-node-pubkey>
+
+# Revoke an org-signed node certificate
+meshguard org-revoke <node-pubkey> --reason admin-removed
 ```
 
 ### Revocation
@@ -123,9 +126,11 @@ The wire protocol supports signed `OrgCertRevoke` messages, which are
 propagated via gossip and enforced by peers that receive them. The receive-side
 verification signs the revoked node key, reason, and Lamport timestamp.
 
-The current CLI does not expose an `org-revoke` command yet. Until signer
-tooling is added, operational revocation is still done by removing individual
-trust files or rotating/reissuing org trust material.
+Org admins revoke an org-signed node with `meshguard org-revoke`. The command
+loads the local org signing key, writes a signed `OrgCertRevoke` message under
+`revoked/`, and `meshguard up` queues the saved revocation for best-effort
+broadcast to known peers. Individual trust files can still be removed locally
+with `meshguard revoke` when a peer was admitted outside org trust.
 
 ### Org Vouch (External Peers)
 
@@ -141,7 +146,7 @@ All nodes trusting the vouching org will auto-accept the standalone node. This i
 
 - Cross-org peering without full membership
 - Onboarding partners to a fleet
-- Temporary trust grants (revocable once signed revocation tooling is exposed)
+- Temporary trust grants that can later be revoked with `meshguard org-revoke`
 
 ### Authorization Flow
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -306,6 +306,25 @@ meshguard org-vouch <node-key-or-path>
 
 ---
 
+## `meshguard org-revoke`
+
+Sign an organization certificate revocation for a node key.
+
+```bash
+meshguard org-revoke <node-key-or-path> [--reason <reason>]
+```
+
+| Argument | Description |
+| -------- | ----------- |
+| `<node-key-or-path>` | Base64 public key string _or_ path to a `.pub` file |
+| `--reason` | `unspecified`, `key-compromised`, or `admin-removed` (default) |
+
+The command loads `$MESHGUARD_CONFIG_DIR/org/org.key`, writes a signed
+`OrgCertRevoke` wire message to `$MESHGUARD_CONFIG_DIR/revoked/*.revoke`, and
+queues that revocation for broadcast the next time `meshguard up` runs.
+
+---
+
 ## `meshguard upgrade`
 
 Upgrade meshguard to the latest release from GitHub.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -322,6 +322,9 @@ meshguard org-revoke <node-key-or-path> [--reason <reason>]
 The command loads `$MESHGUARD_CONFIG_DIR/org/org.key`, writes a signed
 `OrgCertRevoke` wire message to `$MESHGUARD_CONFIG_DIR/revoked/*.revoke`, and
 queues that revocation for broadcast the next time `meshguard up` runs.
+Revocations are scoped to the issuing org: they invalidate that org's
+certificate or vouch for the node, not certificates or vouches from other
+trusted orgs.
 
 ---
 

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -99,6 +99,7 @@ const OrgControlSlot = struct {
     len: u16,
     remaining: u32,
 };
+const MAX_ORG_CONTROL_QUEUE: usize = Org.MAX_ORG_REVOKES;
 
 /// Pending ping tracking.
 const PendingPing = struct {
@@ -175,7 +176,7 @@ pub const SwimProtocol = struct {
     gossip_count: usize = 0,
 
     // Signed org control messages queued for best-effort broadcast to peers.
-    org_control_queue: [16]OrgControlSlot = std.mem.zeroes([16]OrgControlSlot),
+    org_control_queue: [MAX_ORG_CONTROL_QUEUE]OrgControlSlot = std.mem.zeroes([MAX_ORG_CONTROL_QUEUE]OrgControlSlot),
     org_control_count: usize = 0,
 
     // Unauthenticated gossip endpoint hints. These are never exposed as members,

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -179,6 +179,11 @@ pub const SwimProtocol = struct {
     org_control_queue: [MAX_ORG_CONTROL_QUEUE]OrgControlSlot = std.mem.zeroes([MAX_ORG_CONTROL_QUEUE]OrgControlSlot),
     org_control_count: usize = 0,
 
+    // Verified/signed revocations retained for periodic re-broadcast.
+    org_revokes: [Org.MAX_ORG_REVOKES]messages.OrgCertRevoke = std.mem.zeroes([Org.MAX_ORG_REVOKES]messages.OrgCertRevoke),
+    org_revoke_count: usize = 0,
+    last_org_revoke_readvertise_ns: i128 = 0,
+
     // Unauthenticated gossip endpoint hints. These are never exposed as members,
     // never re-gossiped, and only exist to trigger bounded direct certificate probes.
     candidate_peers: [MAX_CANDIDATE_PEERS]CandidatePeer = std.mem.zeroes([MAX_CANDIDATE_PEERS]CandidatePeer),
@@ -481,6 +486,7 @@ pub const SwimProtocol = struct {
         // 5. Probe at most one unauthenticated candidate endpoint.
         self.retransmitStalledHandshakes(now_ns);
         self.readvertiseSelf(now_ns);
+        self.readvertiseOrgRevokes(now_ns);
         self.broadcastOrgControlQueue();
 
         self.probeCandidatePeer(now_ns);
@@ -508,11 +514,10 @@ pub const SwimProtocol = struct {
 
     /// Queue a signed org revocation for local application and peer broadcast.
     pub fn queueOrgCertRevoke(self: *SwimProtocol, rev: messages.OrgCertRevoke) void {
-        var buf: [Org.ORG_REVOKE_WIRE_SIZE]u8 = undefined;
-        const written = codec.encodeOrgCertRevoke(&buf, rev) catch return;
-        self.enqueueOrgControl(buf[0..written]);
+        self.rememberOrgRevoke(rev);
+        self.enqueueOrgRevokeBroadcast(rev);
         if (self.isOrgAuthorizedPeer(rev.org_pubkey)) {
-            self.handleOrgRevoke(rev);
+            self.applyOrgRevoke(rev, false);
         }
     }
 
@@ -554,6 +559,7 @@ pub const SwimProtocol = struct {
         // 4. Probe at most one unauthenticated candidate endpoint.
         self.retransmitStalledHandshakes(now_ns);
         self.readvertiseSelf(now_ns);
+        self.readvertiseOrgRevokes(now_ns);
         self.broadcastOrgControlQueue();
 
         self.probeCandidatePeer(now_ns);
@@ -786,10 +792,17 @@ pub const SwimProtocol = struct {
 
     /// Handle an OrgCertRevoke: add the revoked node pubkey to the set.
     fn handleOrgRevoke(self: *SwimProtocol, rev: messages.OrgCertRevoke) void {
+        self.applyOrgRevoke(rev, true);
+    }
+
+    fn applyOrgRevoke(self: *SwimProtocol, rev: messages.OrgCertRevoke, rebroadcast: bool) void {
         const signed = codec.orgRevokeSignedBytes(rev);
         if (!self.orgSignatureValid(rev.org_pubkey, &signed, rev.signature)) {
             log.warn("org revoke rejected: invalid or untrusted org signature", .{});
             return;
+        }
+        if (rebroadcast) {
+            self.rememberOrgRevoke(rev);
         }
         // Check if already revoked
         for (self.revoked_nodes[0..self.revoked_count]) |revoked| {
@@ -811,6 +824,9 @@ pub const SwimProtocol = struct {
                     }
                 }
             }
+        }
+        if (rebroadcast) {
+            self.enqueueOrgRevokeBroadcast(rev);
         }
     }
 
@@ -1373,8 +1389,38 @@ pub const SwimProtocol = struct {
         }
     }
 
+    fn orgRevokeKnown(self: *const SwimProtocol, rev: messages.OrgCertRevoke) bool {
+        for (self.org_revokes[0..self.org_revoke_count]) |known| {
+            if (std.mem.eql(u8, &known.org_pubkey, &rev.org_pubkey) and
+                std.mem.eql(u8, &known.node_pubkey, &rev.node_pubkey) and
+                known.reason == rev.reason and
+                known.lamport == rev.lamport and
+                std.mem.eql(u8, &known.signature, &rev.signature))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    fn rememberOrgRevoke(self: *SwimProtocol, rev: messages.OrgCertRevoke) void {
+        if (self.orgRevokeKnown(rev)) return;
+        if (self.org_revoke_count >= self.org_revokes.len) return;
+        self.org_revokes[self.org_revoke_count] = rev;
+        self.org_revoke_count += 1;
+    }
+
+    fn enqueueOrgRevokeBroadcast(self: *SwimProtocol, rev: messages.OrgCertRevoke) void {
+        var buf: [Org.ORG_REVOKE_WIRE_SIZE]u8 = undefined;
+        const written = codec.encodeOrgCertRevoke(&buf, rev) catch return;
+        self.enqueueOrgControl(buf[0..written]);
+    }
+
     fn enqueueOrgControl(self: *SwimProtocol, data: []const u8) void {
         if (data.len > Org.ORG_REVOKE_WIRE_SIZE) return;
+        for (self.org_control_queue[0..self.org_control_count]) |slot| {
+            if (slot.len == data.len and std.mem.eql(u8, slot.data[0..slot.len], data)) return;
+        }
         if (self.org_control_count >= self.org_control_queue.len) return;
 
         var slot = OrgControlSlot{
@@ -1409,6 +1455,18 @@ pub const SwimProtocol = struct {
             }
         }
         self.org_control_count = write;
+    }
+
+    fn readvertiseOrgRevokes(self: *SwimProtocol, now: i128) void {
+        if (self.org_revoke_count == 0) return;
+        const interval_ns: i128 = @as(i128, self.config.self_readvertise_interval_ms) * 1_000_000;
+        if (interval_ns <= 0) return;
+        if (now - self.last_org_revoke_readvertise_ns < interval_ns) return;
+        self.last_org_revoke_readvertise_ns = now;
+
+        for (self.org_revokes[0..self.org_revoke_count]) |rev| {
+            self.enqueueOrgRevokeBroadcast(rev);
+        }
     }
 
     /// Enqueue a fresh advertisement of ourselves (identity + wg_pubkey +
@@ -2224,6 +2282,8 @@ test "org revoke requires a valid trusted-org signature (C2 regression)" {
     swim.handleOrgRevoke(valid);
     try std.testing.expect(membership.peers.get(victim).?.state == .dead);
     try std.testing.expectEqual(@as(usize, 1), swim.revoked_count);
+    try std.testing.expectEqual(@as(usize, 1), swim.org_revoke_count);
+    try std.testing.expectEqual(@as(usize, 1), swim.org_control_count);
 
     // (3) Untrusted org with a valid self-signature → rejected.
     const evil_kp = keys.generate();
@@ -2255,8 +2315,33 @@ test "queued org revoke is applied locally and retained for broadcast" {
     swim.queueOrgCertRevoke(rev);
 
     try std.testing.expectEqual(@as(usize, 1), swim.org_control_count);
+    try std.testing.expectEqual(@as(usize, 1), swim.org_revoke_count);
     try std.testing.expectEqual(@as(usize, 1), swim.revoked_count);
     try std.testing.expect(membership.peers.get(victim).?.state == .dead);
+}
+
+test "retained org revoke can be re-advertised without duplicate queue entries" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    var swim = SwimProtocol.init(&membership, inertTestSocket(), .{ .self_readvertise_interval_ms = 1 }, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, null);
+
+    const org_kp = Org.generateOrgKeyPair();
+    const victim = [_]u8{0x7a} ** 32;
+    const rev = try Org.issueOrgRevoke(org_kp, victim, 2, 11);
+
+    swim.queueOrgCertRevoke(rev);
+    try std.testing.expectEqual(@as(usize, 1), swim.org_revoke_count);
+    try std.testing.expectEqual(@as(usize, 1), swim.org_control_count);
+
+    swim.readvertiseOrgRevokes(2_000_000);
+    try std.testing.expectEqual(@as(usize, 1), swim.org_control_count);
+
+    swim.org_control_count = 0;
+    swim.last_org_revoke_readvertise_ns = 0;
+    swim.readvertiseOrgRevokes(2_000_000);
+    try std.testing.expectEqual(@as(usize, 1), swim.org_control_count);
 }
 
 test "gossiped dead does not instantly evict a third party (H2 regression)" {

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -94,6 +94,12 @@ const GossipSlot = struct {
     remaining: u32, // broadcasts remaining before expiry
 };
 
+const OrgControlSlot = struct {
+    data: [Org.ORG_REVOKE_WIRE_SIZE]u8,
+    len: u16,
+    remaining: u32,
+};
+
 /// Pending ping tracking.
 const PendingPing = struct {
     target_pubkey: [32]u8,
@@ -167,6 +173,10 @@ pub const SwimProtocol = struct {
     // Gossip queue with broadcast counters
     gossip_queue: [32]GossipSlot = std.mem.zeroes([32]GossipSlot),
     gossip_count: usize = 0,
+
+    // Signed org control messages queued for best-effort broadcast to peers.
+    org_control_queue: [16]OrgControlSlot = std.mem.zeroes([16]OrgControlSlot),
+    org_control_count: usize = 0,
 
     // Unauthenticated gossip endpoint hints. These are never exposed as members,
     // never re-gossiped, and only exist to trigger bounded direct certificate probes.
@@ -470,6 +480,7 @@ pub const SwimProtocol = struct {
         // 5. Probe at most one unauthenticated candidate endpoint.
         self.retransmitStalledHandshakes(now_ns);
         self.readvertiseSelf(now_ns);
+        self.broadcastOrgControlQueue();
 
         self.probeCandidatePeer(now_ns);
 
@@ -491,6 +502,16 @@ pub const SwimProtocol = struct {
             // Send a ping to each seed — we don't know their pubkey yet,
             // so we use a zero pubkey as "hello" ping
             self.sendPing(seed, [_]u8{0} ** 32);
+        }
+    }
+
+    /// Queue a signed org revocation for local application and peer broadcast.
+    pub fn queueOrgCertRevoke(self: *SwimProtocol, rev: messages.OrgCertRevoke) void {
+        var buf: [Org.ORG_REVOKE_WIRE_SIZE]u8 = undefined;
+        const written = codec.encodeOrgCertRevoke(&buf, rev) catch return;
+        self.enqueueOrgControl(buf[0..written]);
+        if (self.isOrgAuthorizedPeer(rev.org_pubkey)) {
+            self.handleOrgRevoke(rev);
         }
     }
 
@@ -532,6 +553,7 @@ pub const SwimProtocol = struct {
         // 4. Probe at most one unauthenticated candidate endpoint.
         self.retransmitStalledHandshakes(now_ns);
         self.readvertiseSelf(now_ns);
+        self.broadcastOrgControlQueue();
 
         self.probeCandidatePeer(now_ns);
 
@@ -1348,6 +1370,44 @@ pub const SwimProtocol = struct {
             };
             self.gossip_count += 1;
         }
+    }
+
+    fn enqueueOrgControl(self: *SwimProtocol, data: []const u8) void {
+        if (data.len > Org.ORG_REVOKE_WIRE_SIZE) return;
+        if (self.org_control_count >= self.org_control_queue.len) return;
+
+        var slot = OrgControlSlot{
+            .data = std.mem.zeroes([Org.ORG_REVOKE_WIRE_SIZE]u8),
+            .len = @intCast(data.len),
+            .remaining = self.config.max_gossip_broadcasts,
+        };
+        @memcpy(slot.data[0..data.len], data);
+        self.org_control_queue[self.org_control_count] = slot;
+        self.org_control_count += 1;
+    }
+
+    fn broadcastOrgControlQueue(self: *SwimProtocol) void {
+        if (self.org_control_count == 0) return;
+
+        var write: usize = 0;
+        for (0..self.org_control_count) |read| {
+            var slot = self.org_control_queue[read];
+            var sent_any = false;
+            var iter = self.membership.peers.iterator();
+            while (iter.next()) |entry| {
+                if (entry.value_ptr.state == .dead) continue;
+                const ep = entry.value_ptr.gossip_endpoint orelse continue;
+                self.gossipSend(slot.data[0..slot.len], ep);
+                sent_any = true;
+            }
+
+            if (sent_any) slot.remaining -|= 1;
+            if (slot.remaining > 0) {
+                self.org_control_queue[write] = slot;
+                write += 1;
+            }
+        }
+        self.org_control_count = write;
     }
 
     /// Enqueue a fresh advertisement of ourselves (identity + wg_pubkey +
@@ -2174,6 +2234,28 @@ test "org revoke requires a valid trusted-org signature (C2 regression)" {
     evil.signature = keys.sign(&evil_signed, evil_kp.secret_key) catch unreachable;
     swim.handleOrgRevoke(evil);
     try std.testing.expect(membership.peers.get(victim2).?.state == .alive);
+}
+
+test "queued org revoke is applied locally and retained for broadcast" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    var swim = SwimProtocol.init(&membership, inertTestSocket(), .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, null);
+
+    const org_kp = Org.generateOrgKeyPair();
+    const org_pubkey = org_kp.public_key.toBytes();
+    swim.addTrustedOrg(org_pubkey);
+
+    const victim = [_]u8{0x79} ** 32;
+    try membership.upsert(aliveTestPeer(victim));
+    const rev = try Org.issueOrgRevoke(org_kp, victim, 2, 10);
+
+    swim.queueOrgCertRevoke(rev);
+
+    try std.testing.expectEqual(@as(usize, 1), swim.org_control_count);
+    try std.testing.expectEqual(@as(usize, 1), swim.revoked_count);
+    try std.testing.expect(membership.peers.get(victim).?.state == .dead);
 }
 
 test "gossiped dead does not instantly evict a third party (H2 regression)" {

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -102,6 +102,11 @@ const OrgControlSlot = struct {
 };
 const MAX_ORG_CONTROL_QUEUE: usize = Org.MAX_ORG_REVOKES;
 
+const OrgRevokedNode = struct {
+    org_pubkey: [32]u8,
+    node_pubkey: [32]u8,
+};
+
 /// Pending ping tracking.
 const PendingPing = struct {
     target_pubkey: [32]u8,
@@ -213,8 +218,8 @@ pub const SwimProtocol = struct {
     alias_lamports: [16]u64 = std.mem.zeroes([16]u64),
     alias_count: usize = 0,
 
-    // Revoked node pubkeys (propagated via gossip)
-    revoked_nodes: [64][32]u8 = std.mem.zeroes([64][32]u8),
+    // Org-scoped revoked node pubkeys (propagated via gossip)
+    revoked_nodes: [64]OrgRevokedNode = std.mem.zeroes([64]OrgRevokedNode),
     revoked_count: usize = 0,
 
     // Vouched external nodes: org admin vouches for standalone nodes (propagated via gossip)
@@ -289,9 +294,13 @@ pub const SwimProtocol = struct {
         self.enforce_trust = true;
     }
 
-    fn nodeIsRevoked(self: *const SwimProtocol, pubkey: [32]u8) bool {
+    fn orgRevokesNode(self: *const SwimProtocol, org_pubkey: [32]u8, node_pubkey: [32]u8) bool {
         for (self.revoked_nodes[0..self.revoked_count]) |revoked| {
-            if (std.mem.eql(u8, &revoked, &pubkey)) return true;
+            if (std.mem.eql(u8, &revoked.org_pubkey, &org_pubkey) and
+                std.mem.eql(u8, &revoked.node_pubkey, &node_pubkey))
+            {
+                return true;
+            }
         }
         return false;
     }
@@ -307,7 +316,7 @@ pub const SwimProtocol = struct {
         if (!Org.verifyCertificate(&cert)) return false;
         if (!cert.isValid()) return false;
         if (!self.isOrgAuthorizedPeer(cert.org_pubkey)) return false;
-        if (self.nodeIsRevoked(pubkey)) return false;
+        if (self.orgRevokesNode(cert.org_pubkey, pubkey)) return false;
         return true;
     }
 
@@ -317,7 +326,7 @@ pub const SwimProtocol = struct {
         const expires_at = peer.cert_expires_at orelse return false;
         if (!self.isOrgAuthorizedPeer(org_pubkey)) return false;
         if (!certExpiryValid(expires_at)) return false;
-        if (self.nodeIsRevoked(pubkey)) return false;
+        if (self.orgRevokesNode(org_pubkey, pubkey)) return false;
         return true;
     }
 
@@ -342,10 +351,6 @@ pub const SwimProtocol = struct {
         for (self.authorized_keys[0..self.authorized_count]) |key| {
             if (std.mem.eql(u8, &key, &pubkey)) return true;
         }
-        // Check if revoked
-        for (self.revoked_nodes[0..self.revoked_count]) |revoked| {
-            if (std.mem.eql(u8, &revoked, &pubkey)) return false;
-        }
         // Check previously admitted org certificate
         if (self.recordedCertAuthorizesPeer(pubkey)) return true;
         // Check presented org certificate
@@ -356,7 +361,11 @@ pub const SwimProtocol = struct {
         for (0..self.vouched_count) |i| {
             if (std.mem.eql(u8, &self.vouched_node_keys[i], &pubkey)) {
                 // Verify the vouching org is trusted
-                if (self.isOrgAuthorizedPeer(self.vouched_org_keys[i])) return true;
+                if (self.isOrgAuthorizedPeer(self.vouched_org_keys[i]) and
+                    !self.orgRevokesNode(self.vouched_org_keys[i], pubkey))
+                {
+                    return true;
+                }
             }
         }
         return false;
@@ -805,20 +814,24 @@ pub const SwimProtocol = struct {
         if (rebroadcast) {
             self.rememberOrgRevoke(rev);
         }
-        // Check if already revoked
-        for (self.revoked_nodes[0..self.revoked_count]) |revoked| {
-            if (std.mem.eql(u8, &revoked, &rev.node_pubkey)) return;
-        }
+        if (self.orgRevokesNode(rev.org_pubkey, rev.node_pubkey)) return;
 
         // Add to revocation set
         if (self.revoked_count < self.revoked_nodes.len) {
-            self.revoked_nodes[self.revoked_count] = rev.node_pubkey;
+            self.revoked_nodes[self.revoked_count] = .{
+                .org_pubkey = rev.org_pubkey,
+                .node_pubkey = rev.node_pubkey,
+            };
             self.revoked_count += 1;
             log.warn("node revoked by org (reason={d})", .{rev.reason});
 
-            // If the revoked node is currently a peer, mark as dead
+            // If the revoked node is currently authorized only by this org's
+            // cert/vouch, mark it dead. Other orgs or explicit key trust are
+            // independent authorization boundaries.
             if (self.membership.peers.getPtr(rev.node_pubkey)) |peer| {
-                if (peer.state == .alive or peer.state == .suspected) {
+                if ((peer.state == .alive or peer.state == .suspected) and
+                    !self.isAuthorizedPeer(rev.node_pubkey, null))
+                {
                     self.membership.markDead(rev.node_pubkey);
                     if (self.handler) |h| {
                         h.onPeerDead(h.ctx, rev.node_pubkey);
@@ -850,12 +863,11 @@ pub const SwimProtocol = struct {
             }
         }
 
-        // Don't vouch for revoked nodes
-        for (self.revoked_nodes[0..self.revoked_count]) |revoked| {
-            if (std.mem.eql(u8, &revoked, &vouch.vouched_pubkey)) {
-                log.warn("org vouch rejected: node is revoked", .{});
-                return;
-            }
+        // Don't re-vouch a node already revoked by this same org. A different
+        // trusted org's revocation does not cancel this org's authority.
+        if (self.orgRevokesNode(vouch.org_pubkey, vouch.vouched_pubkey)) {
+            log.warn("org vouch rejected: node is revoked", .{});
+            return;
         }
 
         // Register the vouch
@@ -1285,7 +1297,6 @@ pub const SwimProtocol = struct {
 
     fn learnCandidatePeer(self: *SwimProtocol, pubkey: [32]u8, endpoint: messages.Endpoint) void {
         if (self.membership.peers.getPtr(pubkey) != null) return;
-        if (self.nodeIsRevoked(pubkey)) return;
 
         const now = nowNs();
         for (self.candidate_peers[0..self.candidate_count]) |*candidate| {
@@ -1829,6 +1840,18 @@ fn issueCertWire(org_kp: Org.OrgKeyPair, node_pubkey: [32]u8, name: []const u8) 
     return cert_wire;
 }
 
+fn issueVouch(org_kp: Org.OrgKeyPair, node_pubkey: [32]u8, lamport: u64) messages.OrgTrustVouch {
+    var vouch = messages.OrgTrustVouch{
+        .org_pubkey = org_kp.public_key.toBytes(),
+        .vouched_pubkey = node_pubkey,
+        .lamport = lamport,
+        .signature = undefined,
+    };
+    const signed = codec.orgVouchSignedBytes(vouch);
+    vouch.signature = keys.sign(&signed, org_kp.secret_key) catch unreachable;
+    return vouch;
+}
+
 test "peer restart is detected by incarnation and steady state is not" {
     const allocator = std.testing.allocator;
     var membership = Membership.MembershipTable.init(allocator, 5000);
@@ -2285,7 +2308,10 @@ test "valid trusted org cert admits and records peer until revoked" {
     try std.testing.expectEqual(@as(?i64, 0), recorded.cert_expires_at);
     try std.testing.expect(swim.isAuthorizedPeer(node_pubkey, null));
 
-    swim.revoked_nodes[0] = node_pubkey;
+    swim.revoked_nodes[0] = .{
+        .org_pubkey = org_pubkey,
+        .node_pubkey = node_pubkey,
+    };
     swim.revoked_count = 1;
     try std.testing.expect(!swim.isAuthorizedPeer(node_pubkey, null));
     try std.testing.expect(!swim.isAuthorizedPeer(node_pubkey, cert_wire));
@@ -2299,6 +2325,7 @@ test "org revoke requires a valid trusted-org signature (C2 regression)" {
     defer socket.close();
 
     var swim = SwimProtocol.init(&membership, socket, .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, null);
+    swim.enableTrust();
 
     const org_kp = keys.generate();
     const org_pubkey = org_kp.public_key.toBytes();
@@ -2306,6 +2333,11 @@ test "org revoke requires a valid trusted-org signature (C2 regression)" {
 
     const victim = [_]u8{0x77} ** 32;
     try membership.upsert(aliveTestPeer(victim));
+    const victim_cert = try issueCertWire(.{
+        .public_key = org_kp.public_key,
+        .secret_key = org_kp.secret_key,
+    }, victim, "victim");
+    swim.recordPeerCertificate(victim, victim_cert);
 
     // (1) Forged: trusted org pubkey but an all-zero signature → rejected.
     const forged = messages.OrgCertRevoke{ .org_pubkey = org_pubkey, .node_pubkey = victim, .reason = 2, .lamport = 5, .signature = [_]u8{0} ** 64 };
@@ -2335,12 +2367,90 @@ test "org revoke requires a valid trusted-org signature (C2 regression)" {
     try std.testing.expect(membership.peers.get(victim2).?.state == .alive);
 }
 
+test "org revokes are scoped to certificate issuer" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    var swim = SwimProtocol.init(&membership, inertTestSocket(), .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, null);
+    swim.enableTrust();
+
+    const org_a = Org.generateOrgKeyPair();
+    const org_b = Org.generateOrgKeyPair();
+    const org_a_pub = org_a.public_key.toBytes();
+    const org_b_pub = org_b.public_key.toBytes();
+    swim.addTrustedOrg(org_a_pub);
+    swim.addTrustedOrg(org_b_pub);
+
+    const node = [_]u8{0x89} ** 32;
+    const cert_b = try issueCertWire(org_b, node, "node-b");
+    try membership.upsert(aliveTestPeer(node));
+    swim.recordPeerCertificate(node, cert_b);
+    try std.testing.expect(swim.isAuthorizedPeer(node, null));
+
+    const revoke_from_a = try Org.issueOrgRevoke(org_a, node, 2, 20);
+    swim.handleOrgRevoke(revoke_from_a);
+
+    try std.testing.expectEqual(@as(usize, 1), swim.revoked_count);
+    try std.testing.expect(swim.orgRevokesNode(org_a_pub, node));
+    try std.testing.expect(swim.isAuthorizedPeer(node, null));
+    try std.testing.expect(swim.isAuthorizedPeer(node, cert_b));
+    try std.testing.expect(membership.peers.get(node).?.state == .alive);
+
+    const revoke_from_b = try Org.issueOrgRevoke(org_b, node, 2, 21);
+    swim.handleOrgRevoke(revoke_from_b);
+
+    try std.testing.expectEqual(@as(usize, 2), swim.revoked_count);
+    try std.testing.expect(swim.orgRevokesNode(org_b_pub, node));
+    try std.testing.expect(!swim.isAuthorizedPeer(node, null));
+    try std.testing.expect(!swim.isAuthorizedPeer(node, cert_b));
+    try std.testing.expect(membership.peers.get(node).?.state == .dead);
+}
+
+test "org revokes are scoped to vouch issuer" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+
+    var swim = SwimProtocol.init(&membership, inertTestSocket(), .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, null);
+    swim.enableTrust();
+
+    const org_a = Org.generateOrgKeyPair();
+    const org_b = Org.generateOrgKeyPair();
+    const org_a_pub = org_a.public_key.toBytes();
+    const org_b_pub = org_b.public_key.toBytes();
+    swim.addTrustedOrg(org_a_pub);
+    swim.addTrustedOrg(org_b_pub);
+
+    const node = [_]u8{0x8a} ** 32;
+    swim.handleOrgVouch(issueVouch(org_b, node, 30));
+    try membership.upsert(aliveTestPeer(node));
+    try std.testing.expect(swim.isAuthorizedPeer(node, null));
+
+    const revoke_from_a = try Org.issueOrgRevoke(org_a, node, 2, 31);
+    swim.handleOrgRevoke(revoke_from_a);
+
+    try std.testing.expectEqual(@as(usize, 1), swim.revoked_count);
+    try std.testing.expect(swim.orgRevokesNode(org_a_pub, node));
+    try std.testing.expect(swim.isAuthorizedPeer(node, null));
+    try std.testing.expect(membership.peers.get(node).?.state == .alive);
+
+    const revoke_from_b = try Org.issueOrgRevoke(org_b, node, 2, 32);
+    swim.handleOrgRevoke(revoke_from_b);
+
+    try std.testing.expectEqual(@as(usize, 2), swim.revoked_count);
+    try std.testing.expect(swim.orgRevokesNode(org_b_pub, node));
+    try std.testing.expect(!swim.isAuthorizedPeer(node, null));
+    try std.testing.expect(membership.peers.get(node).?.state == .dead);
+}
+
 test "queued org revoke is applied locally and retained for broadcast" {
     const allocator = std.testing.allocator;
     var membership = Membership.MembershipTable.init(allocator, 5000);
     defer membership.deinit();
 
     var swim = SwimProtocol.init(&membership, inertTestSocket(), .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, null);
+    swim.enableTrust();
 
     const org_kp = Org.generateOrgKeyPair();
     const org_pubkey = org_kp.public_key.toBytes();
@@ -2348,6 +2458,8 @@ test "queued org revoke is applied locally and retained for broadcast" {
 
     const victim = [_]u8{0x79} ** 32;
     try membership.upsert(aliveTestPeer(victim));
+    const cert = try issueCertWire(org_kp, victim, "victim");
+    swim.recordPeerCertificate(victim, cert);
     const rev = try Org.issueOrgRevoke(org_kp, victim, 2, 10);
 
     swim.queueOrgCertRevoke(rev);

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -98,6 +98,7 @@ const OrgControlSlot = struct {
     data: [Org.ORG_REVOKE_WIRE_SIZE]u8,
     len: u16,
     remaining: u32,
+    next_peer_index: usize,
 };
 const MAX_ORG_CONTROL_QUEUE: usize = Org.MAX_ORG_REVOKES;
 
@@ -1129,7 +1130,7 @@ pub const SwimProtocol = struct {
     /// be amplified into a flood. Over-budget packets are dropped (counted),
     /// which is correct for an unreliable gossip protocol. Tunnel DATA does not
     /// use this path, so egress throughput is unaffected.
-    fn gossipSend(self: *SwimProtocol, data: []const u8, endpoint: messages.Endpoint) void {
+    fn tryGossipSend(self: *SwimProtocol, data: []const u8, endpoint: messages.Endpoint) bool {
         const now = nowNs();
         if (self.last_token_refill_ns == 0) self.last_token_refill_ns = now;
         const elapsed_s: f64 = @as(f64, @floatFromInt(now - self.last_token_refill_ns)) / 1_000_000_000.0;
@@ -1137,11 +1138,16 @@ pub const SwimProtocol = struct {
         self.send_tokens = @min(SEND_BURST, self.send_tokens + elapsed_s * SEND_RATE_PPS);
         if (self.send_tokens < 1.0) {
             self.sends_dropped_ratelimit +%= 1;
-            return; // over budget — drop to protect the network
+            return false; // over budget: drop to protect the network
         }
         self.send_tokens -= 1.0;
-        _ = self.socket.sendToEndpoint(data, endpoint) catch return;
+        _ = self.socket.sendToEndpoint(data, endpoint) catch return false;
         self.pkts_sent +%= 1;
+        return true;
+    }
+
+    fn gossipSend(self: *SwimProtocol, data: []const u8, endpoint: messages.Endpoint) void {
+        _ = self.tryGossipSend(data, endpoint);
     }
 
     fn sendPing(self: *SwimProtocol, endpoint: messages.Endpoint, target_pubkey: [32]u8) void {
@@ -1427,10 +1433,41 @@ pub const SwimProtocol = struct {
             .data = std.mem.zeroes([Org.ORG_REVOKE_WIRE_SIZE]u8),
             .len = @intCast(data.len),
             .remaining = self.config.max_gossip_broadcasts,
+            .next_peer_index = 0,
         };
         @memcpy(slot.data[0..data.len], data);
         self.org_control_queue[self.org_control_count] = slot;
         self.org_control_count += 1;
+    }
+
+    fn orgControlRecipientCount(self: *const SwimProtocol) usize {
+        var count: usize = 0;
+        var iter = self.membership.peers.iterator();
+        while (iter.next()) |entry| {
+            if (entry.value_ptr.state == .dead) continue;
+            if (entry.value_ptr.gossip_endpoint == null) continue;
+            count += 1;
+        }
+        return count;
+    }
+
+    fn sendOrgControlFromCursor(self: *SwimProtocol, slot: *OrgControlSlot, recipient_count: usize) bool {
+        var recipient_index: usize = 0;
+        var iter = self.membership.peers.iterator();
+        while (iter.next()) |entry| {
+            if (entry.value_ptr.state == .dead) continue;
+            const ep = entry.value_ptr.gossip_endpoint orelse continue;
+            const current_index = recipient_index;
+            recipient_index += 1;
+            if (current_index < slot.next_peer_index) continue;
+
+            if (!self.tryGossipSend(slot.data[0..slot.len], ep)) {
+                slot.next_peer_index = current_index;
+                return false;
+            }
+            slot.next_peer_index = current_index + 1;
+        }
+        return slot.next_peer_index >= recipient_count;
     }
 
     fn broadcastOrgControlQueue(self: *SwimProtocol) void {
@@ -1439,16 +1476,17 @@ pub const SwimProtocol = struct {
         var write: usize = 0;
         for (0..self.org_control_count) |read| {
             var slot = self.org_control_queue[read];
-            var sent_any = false;
-            var iter = self.membership.peers.iterator();
-            while (iter.next()) |entry| {
-                if (entry.value_ptr.state == .dead) continue;
-                const ep = entry.value_ptr.gossip_endpoint orelse continue;
-                self.gossipSend(slot.data[0..slot.len], ep);
-                sent_any = true;
+            const recipient_count = self.orgControlRecipientCount();
+            if (recipient_count == 0) {
+                slot.next_peer_index = 0;
+            } else {
+                if (slot.next_peer_index > recipient_count) slot.next_peer_index = recipient_count;
+                if (self.sendOrgControlFromCursor(&slot, recipient_count)) {
+                    slot.next_peer_index = 0;
+                    slot.remaining -|= 1;
+                }
             }
 
-            if (sent_any) slot.remaining -|= 1;
             if (slot.remaining > 0) {
                 self.org_control_queue[write] = slot;
                 write += 1;
@@ -2342,6 +2380,49 @@ test "retained org revoke can be re-advertised without duplicate queue entries" 
     swim.last_org_revoke_readvertise_ns = 0;
     swim.readvertiseOrgRevokes(2_000_000);
     try std.testing.expectEqual(@as(usize, 1), swim.org_control_count);
+}
+
+test "org revoke fan-out resumes after rate-limit drops" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+    var socket = Udp.UdpSocket.bind(0) catch return;
+    defer socket.close();
+
+    var swim = SwimProtocol.init(&membership, socket, .{ .max_gossip_broadcasts = 1 }, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, null);
+
+    var i: usize = 0;
+    while (i < 3) : (i += 1) {
+        var peer = aliveTestPeer([_]u8{@intCast(i + 3)} ** 32);
+        peer.gossip_endpoint = messages.Endpoint.initV4(.{ 127, 0, 0, 1 }, @intCast(43000 + i));
+        try membership.upsert(peer);
+    }
+
+    const data = [_]u8{0x42} ** Org.ORG_REVOKE_WIRE_SIZE;
+    swim.enqueueOrgControl(&data);
+    try std.testing.expectEqual(@as(usize, 1), swim.org_control_count);
+
+    swim.send_tokens = 1;
+    swim.last_token_refill_ns = nowNs();
+    swim.broadcastOrgControlQueue();
+    try std.testing.expectEqual(@as(usize, 1), swim.org_control_count);
+    try std.testing.expectEqual(@as(u32, 1), swim.org_control_queue[0].remaining);
+    try std.testing.expectEqual(@as(usize, 1), swim.org_control_queue[0].next_peer_index);
+    try std.testing.expectEqual(@as(u64, 1), swim.pkts_sent);
+
+    swim.send_tokens = 1;
+    swim.last_token_refill_ns = nowNs();
+    swim.broadcastOrgControlQueue();
+    try std.testing.expectEqual(@as(usize, 1), swim.org_control_count);
+    try std.testing.expectEqual(@as(u32, 1), swim.org_control_queue[0].remaining);
+    try std.testing.expectEqual(@as(usize, 2), swim.org_control_queue[0].next_peer_index);
+    try std.testing.expectEqual(@as(u64, 2), swim.pkts_sent);
+
+    swim.send_tokens = 1;
+    swim.last_token_refill_ns = nowNs();
+    swim.broadcastOrgControlQueue();
+    try std.testing.expectEqual(@as(usize, 0), swim.org_control_count);
+    try std.testing.expectEqual(@as(u64, 3), swim.pkts_sent);
 }
 
 test "gossiped dead does not instantly evict a third party (H2 regression)" {

--- a/src/identity/org.zig
+++ b/src/identity/org.zig
@@ -42,6 +42,7 @@ pub const OrgKeyPair = struct {
 };
 
 pub const ORG_REVOKE_WIRE_SIZE: usize = 1 + 32 + 32 + 1 + 8 + 64;
+pub const MAX_ORG_REVOKES: usize = 64;
 
 /// Fixed-size node certificate signed by an org key.
 /// Total: 186 bytes on the wire.
@@ -384,6 +385,7 @@ pub fn saveOrgRevoke(allocator: std.mem.Allocator, config_dir: []const u8, rev: 
     const filename = try std.fmt.allocPrint(allocator, "{s}.revoke", .{hex});
     defer allocator.free(filename);
     const path = try std.fs.path.join(allocator, &.{ revoke_dir, filename });
+    errdefer allocator.free(path);
 
     var wire: [ORG_REVOKE_WIRE_SIZE]u8 = undefined;
     const written = try codec.encodeOrgCertRevoke(&wire, rev);
@@ -415,7 +417,7 @@ pub fn loadOrgRevocations(allocator: std.mem.Allocator, config_dir: []const u8) 
     const revoke_dir = try std.fs.path.join(allocator, &.{ config_dir, "revoked" });
     defer allocator.free(revoke_dir);
 
-    var temp: [64]messages.OrgCertRevoke = undefined;
+    var temp: [MAX_ORG_REVOKES]messages.OrgCertRevoke = undefined;
     var count: usize = 0;
 
     const dir = std.Io.Dir.openDirAbsolute(zio(), revoke_dir, .{ .iterate = true }) catch |err| {

--- a/src/identity/org.zig
+++ b/src/identity/org.zig
@@ -10,7 +10,8 @@
 const std = @import("std");
 const Ed25519 = std.crypto.sign.Ed25519;
 const Blake3 = std.crypto.hash.Blake3;
-
+const messages = @import("../protocol/messages.zig");
+const codec = @import("../protocol/codec.zig");
 
 /// Read all available bytes from an Io.File into buf. Returns bytes read.
 fn readFileBytes(f: std.Io.File, buf: []u8) !usize {
@@ -33,13 +34,14 @@ fn nowUnixSecs() i64 {
     return @intCast(std.Io.Timestamp.now(zio(), .real).toSeconds());
 }
 
-
 // ─── Types ───
 
 pub const OrgKeyPair = struct {
     public_key: Ed25519.PublicKey,
     secret_key: Ed25519.SecretKey,
 };
+
+pub const ORG_REVOKE_WIRE_SIZE: usize = 1 + 32 + 32 + 1 + 8 + 64;
 
 /// Fixed-size node certificate signed by an org key.
 /// Total: 186 bytes on the wire.
@@ -269,6 +271,55 @@ pub fn issueCertificate(
     return cert;
 }
 
+pub fn parseRevokeReason(reason: []const u8) ?u8 {
+    if (std.mem.eql(u8, reason, "0") or std.mem.eql(u8, reason, "unspecified")) return 0;
+    if (std.mem.eql(u8, reason, "1") or
+        std.mem.eql(u8, reason, "key-compromised") or
+        std.mem.eql(u8, reason, "key_compromised") or
+        std.mem.eql(u8, reason, "compromised"))
+    {
+        return 1;
+    }
+    if (std.mem.eql(u8, reason, "2") or
+        std.mem.eql(u8, reason, "admin-removed") or
+        std.mem.eql(u8, reason, "admin_removed") or
+        std.mem.eql(u8, reason, "removed"))
+    {
+        return 2;
+    }
+    return null;
+}
+
+pub fn revokeReasonName(reason: u8) []const u8 {
+    return switch (reason) {
+        0 => "unspecified",
+        1 => "key-compromised",
+        2 => "admin-removed",
+        else => "unknown",
+    };
+}
+
+/// Create and sign an OrgCertRevoke for a node.
+pub fn issueOrgRevoke(
+    org_kp: OrgKeyPair,
+    node_pubkey: [32]u8,
+    reason: u8,
+    lamport: u64,
+) !messages.OrgCertRevoke {
+    var rev = messages.OrgCertRevoke{
+        .org_pubkey = org_kp.public_key.toBytes(),
+        .node_pubkey = node_pubkey,
+        .reason = reason,
+        .lamport = lamport,
+        .signature = undefined,
+    };
+    const signed = codec.orgRevokeSignedBytes(rev);
+    const kp = try Ed25519.KeyPair.fromSecretKey(org_kp.secret_key);
+    const sig = try kp.sign(&signed, null);
+    rev.signature = sig.toBytes();
+    return rev;
+}
+
 // ─── Deterministic Mesh DNS ───
 
 /// Derive a deterministic org domain from its public key.
@@ -311,6 +362,82 @@ pub fn loadCertificate(allocator: std.mem.Allocator, path: []const u8) !NodeCert
     const n = try readFileBytes(file, &wire);
     if (n < NodeCertificate.WIRE_SIZE) return error.InvalidCertificate;
     return NodeCertificate.deserialize(&wire);
+}
+
+fn keyPrefixHex(pubkey: [32]u8, out: *[16]u8) []const u8 {
+    return std.fmt.bufPrint(out, "{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}", .{
+        pubkey[0], pubkey[1], pubkey[2], pubkey[3],
+        pubkey[4], pubkey[5], pubkey[6], pubkey[7],
+    }) catch "revoke";
+}
+
+/// Save a revocation as a full encoded 0x42 wire message under config_dir/revoked/.
+pub fn saveOrgRevoke(allocator: std.mem.Allocator, config_dir: []const u8, rev: messages.OrgCertRevoke) ![]const u8 {
+    const revoke_dir = try std.fs.path.join(allocator, &.{ config_dir, "revoked" });
+    defer allocator.free(revoke_dir);
+    std.Io.Dir.cwd().createDirPath(zio(), revoke_dir) catch |err| {
+        if (err != error.PathAlreadyExists) return err;
+    };
+
+    var hex_buf: [16]u8 = undefined;
+    const hex = keyPrefixHex(rev.node_pubkey, &hex_buf);
+    const filename = try std.fmt.allocPrint(allocator, "{s}.revoke", .{hex});
+    defer allocator.free(filename);
+    const path = try std.fs.path.join(allocator, &.{ revoke_dir, filename });
+
+    var wire: [ORG_REVOKE_WIRE_SIZE]u8 = undefined;
+    const written = try codec.encodeOrgCertRevoke(&wire, rev);
+    if (written != ORG_REVOKE_WIRE_SIZE) return error.InvalidRevocation;
+
+    const file = try std.Io.Dir.createFileAbsolute(zio(), path, .{});
+    defer file.close(zio());
+    try file.writeStreamingAll(zio(), &wire);
+    return path;
+}
+
+pub fn loadOrgRevoke(allocator: std.mem.Allocator, path: []const u8) !messages.OrgCertRevoke {
+    _ = allocator;
+    const file = try std.Io.Dir.openFileAbsolute(zio(), path, .{});
+    defer file.close(zio());
+
+    var wire: [ORG_REVOKE_WIRE_SIZE]u8 = undefined;
+    const n = try readFileBytes(file, &wire);
+    if (n != ORG_REVOKE_WIRE_SIZE) return error.InvalidRevocation;
+
+    const decoded = try codec.decode(&wire);
+    return switch (decoded) {
+        .org_cert_revoke => |rev| rev,
+        else => error.InvalidRevocation,
+    };
+}
+
+pub fn loadOrgRevocations(allocator: std.mem.Allocator, config_dir: []const u8) ![]messages.OrgCertRevoke {
+    const revoke_dir = try std.fs.path.join(allocator, &.{ config_dir, "revoked" });
+    defer allocator.free(revoke_dir);
+
+    var temp: [64]messages.OrgCertRevoke = undefined;
+    var count: usize = 0;
+
+    const dir = std.Io.Dir.openDirAbsolute(zio(), revoke_dir, .{ .iterate = true }) catch |err| {
+        if (err == error.FileNotFound) return try allocator.alloc(messages.OrgCertRevoke, 0);
+        return err;
+    };
+    defer dir.close(zio());
+
+    var iter = dir.iterate();
+    while (try iter.next(zio())) |entry| {
+        if (!std.mem.endsWith(u8, entry.name, ".revoke")) continue;
+        if (count >= temp.len) break;
+
+        const path = try std.fs.path.join(allocator, &.{ revoke_dir, entry.name });
+        defer allocator.free(path);
+        temp[count] = loadOrgRevoke(allocator, path) catch continue;
+        count += 1;
+    }
+
+    const result = try allocator.alloc(messages.OrgCertRevoke, count);
+    @memcpy(result, temp[0..count]);
+    return result;
 }
 
 // ─── Tests ───
@@ -373,4 +500,63 @@ test "format mesh domain" {
     var buf: [64]u8 = undefined;
     const result = formatMeshDomain("node-1", .{ 'a', '1', 'b', '2', 'c', '3' }, &buf);
     try std.testing.expectEqualStrings("node-1.a1b2c3.mesh", result);
+}
+
+test "org revoke signing uses canonical payload" {
+    const org_kp = generateOrgKeyPair();
+    const node_pubkey = [_]u8{0x42} ** 32;
+    const lamport: u64 = 0x0102030405060708;
+
+    const rev = try issueOrgRevoke(org_kp, node_pubkey, 1, lamport);
+    const signed = codec.orgRevokeSignedBytes(rev);
+
+    try std.testing.expectEqualSlices(u8, &node_pubkey, signed[0..32]);
+    try std.testing.expectEqual(@as(u8, 1), signed[32]);
+    try std.testing.expectEqual(@as(u8, 0x08), signed[33]);
+    try std.testing.expectEqual(@as(u8, 0x07), signed[34]);
+    try std.testing.expectEqual(@as(u8, 0x06), signed[35]);
+    try std.testing.expectEqual(@as(u8, 0x05), signed[36]);
+    try std.testing.expectEqual(@as(u8, 0x04), signed[37]);
+    try std.testing.expectEqual(@as(u8, 0x03), signed[38]);
+    try std.testing.expectEqual(@as(u8, 0x02), signed[39]);
+    try std.testing.expectEqual(@as(u8, 0x01), signed[40]);
+
+    const sig = Ed25519.Signature.fromBytes(rev.signature);
+    try sig.verify(&signed, org_kp.public_key);
+}
+
+test "org revoke save and load round-trip" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(zio(), ".", allocator);
+    defer allocator.free(tmp_path);
+
+    const org_kp = generateOrgKeyPair();
+    const node_pubkey = [_]u8{0x24} ** 32;
+    const rev = try issueOrgRevoke(org_kp, node_pubkey, 2, 123);
+
+    const saved_path = try saveOrgRevoke(allocator, tmp_path, rev);
+    defer allocator.free(saved_path);
+
+    const loaded = try loadOrgRevoke(allocator, saved_path);
+    try std.testing.expectEqualSlices(u8, &rev.org_pubkey, &loaded.org_pubkey);
+    try std.testing.expectEqualSlices(u8, &rev.node_pubkey, &loaded.node_pubkey);
+    try std.testing.expectEqual(rev.reason, loaded.reason);
+    try std.testing.expectEqual(rev.lamport, loaded.lamport);
+    try std.testing.expectEqualSlices(u8, &rev.signature, &loaded.signature);
+
+    const all = try loadOrgRevocations(allocator, tmp_path);
+    defer allocator.free(all);
+    try std.testing.expectEqual(@as(usize, 1), all.len);
+    try std.testing.expectEqualSlices(u8, &rev.node_pubkey, &all[0].node_pubkey);
+}
+
+test "org revoke reason parser" {
+    try std.testing.expectEqual(@as(?u8, 0), parseRevokeReason("unspecified"));
+    try std.testing.expectEqual(@as(?u8, 1), parseRevokeReason("key-compromised"));
+    try std.testing.expectEqual(@as(?u8, 1), parseRevokeReason("1"));
+    try std.testing.expectEqual(@as(?u8, 2), parseRevokeReason("admin_removed"));
+    try std.testing.expectEqual(@as(?u8, null), parseRevokeReason("mystery"));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -4484,24 +4484,14 @@ fn cmdConfigShow(allocator: std.mem.Allocator) !void {
     }
 
     // ─── Org Revocations ───
-    const revoke_dir = std.fs.path.join(allocator, &.{ config_dir, "revoked" }) catch null;
-    defer if (revoke_dir) |rd| allocator.free(rd);
-
-    if (revoke_dir) |rd| {
-        if (std.Io.Dir.openDirAbsolute(zio(), rd, .{ .iterate = true })) |dir| {
-            defer dir.close(zio());
-            var revoke_count: usize = 0;
-            var iter = dir.iterate();
-            while (iter.next(zio()) catch null) |entry| {
-                if (std.mem.endsWith(u8, entry.name, ".revoke")) revoke_count += 1;
-            }
-            if (revoke_count > 0) {
-                try stdout.writeStreamingAll(zio(), "\n");
-                try writeFormatted(stdout, "\x1b[1m─── Org Revocations ({d}) ───────────────────────\x1b[0m\n", .{revoke_count});
-                try writeFormatted(stdout, "  {d} pending revocation(s)\n", .{revoke_count});
-            }
-        } else |_| {}
-    }
+    if (lib.identity.Org.loadOrgRevocations(allocator, config_dir)) |revocations| {
+        defer allocator.free(revocations);
+        if (revocations.len > 0) {
+            try stdout.writeStreamingAll(zio(), "\n");
+            try writeFormatted(stdout, "\x1b[1m─── Org Revocations ({d}) ───────────────────────\x1b[0m\n", .{revocations.len});
+            try writeFormatted(stdout, "  {d} pending revocation(s)\n", .{revocations.len});
+        }
+    } else |_| {}
 
     try stdout.writeStreamingAll(zio(), "\n");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -34,6 +34,7 @@ const usage =
     \\  org-keygen  Generate a new org keypair
     \\  org-sign    Sign a node's key with org key (--name <label>)
     \\  org-vouch   Vouch for an external node (auto-propagates to org members)
+    \\  org-revoke  Sign an org certificate revocation
     \\  config show Show local node configuration (works offline)
     \\  service     Manage service access policies
     \\  upgrade     Upgrade to the latest release from GitHub
@@ -219,6 +220,15 @@ pub fn main(init: std.process.Init) !void {
             std.process.exit(1);
         }
         try cmdOrgVouch(allocator, args[2]);
+        return;
+    }
+
+    if (std.mem.eql(u8, command, "org-revoke")) {
+        if (args.len < 3) {
+            try getStdErr().writeStreamingAll(zio(), "error: 'org-revoke' requires a node public key or .pub file\n");
+            std.process.exit(1);
+        }
+        try cmdOrgRevoke(allocator, args[2], args[3..]);
         return;
     }
 
@@ -648,6 +658,83 @@ fn cmdOrgVouch(allocator: std.mem.Allocator, node_key_arg: []const u8) !void {
     try stdout.writeStreamingAll(zio(), "All nodes trusting this org will auto-accept the vouched node.\n");
 }
 
+fn cmdOrgRevoke(allocator: std.mem.Allocator, node_key_arg: []const u8, extra_args: []const []const u8) !void {
+    const config_dir = try Config.ensureConfigDir(allocator);
+    defer allocator.free(config_dir);
+
+    const stdout = getStdOut();
+    const stderr = getStdErr();
+    const Org = lib.identity.Org;
+
+    var reason: u8 = 2; // admin-removed
+    var i: usize = 0;
+    while (i < extra_args.len) : (i += 1) {
+        if (std.mem.eql(u8, extra_args[i], "--reason")) {
+            if (i + 1 >= extra_args.len) {
+                try stderr.writeStreamingAll(zio(), "error: --reason requires a value\n");
+                std.process.exit(1);
+            }
+            reason = Org.parseRevokeReason(extra_args[i + 1]) orelse {
+                try stderr.writeStreamingAll(zio(), "error: invalid revocation reason (use unspecified, key-compromised, or admin-removed)\n");
+                std.process.exit(1);
+            };
+            i += 1;
+        } else {
+            try writeFormatted(stderr, "error: unknown org-revoke option '{s}'\n", .{extra_args[i]});
+            std.process.exit(1);
+        }
+    }
+
+    const org_kp = Org.loadOrgKeyPair(allocator, config_dir) catch {
+        try stderr.writeStreamingAll(zio(), "error: no org keypair found. Run 'meshguard org-keygen' first.\n");
+        std.process.exit(1);
+    };
+
+    var key_b64_buf: [44]u8 = undefined;
+    var node_pk_bytes: [32]u8 = undefined;
+    if (lib.identity.Trust.validateKey(node_key_arg, &key_b64_buf, &node_pk_bytes)) |err_msg| {
+        try writeFormatted(stderr, "error: {s}\n", .{err_msg});
+        std.process.exit(1);
+    }
+
+    const lamport: u64 = @intCast(@max(nowUnixSecs(), 0));
+    const revoke = Org.issueOrgRevoke(org_kp, node_pk_bytes, reason, lamport) catch {
+        try stderr.writeStreamingAll(zio(), "error: failed to sign revocation\n");
+        std.process.exit(1);
+    };
+
+    const revoke_path = try Org.saveOrgRevoke(allocator, config_dir, revoke);
+    defer allocator.free(revoke_path);
+
+    var node_b64: [44]u8 = undefined;
+    _ = std.base64.standard.Encoder.encode(&node_b64, &node_pk_bytes);
+
+    try stdout.writeStreamingAll(zio(), "Org revocation signed.\n");
+    try writeFormatted(stdout, "  node pubkey: {s}\n", .{node_b64});
+    try writeFormatted(stdout, "  reason:      {s} ({d})\n", .{ Org.revokeReasonName(reason), reason });
+    try writeFormatted(stdout, "  lamport:     {d}\n", .{lamport});
+    try writeFormatted(stdout, "  saved to:    {s}\n", .{revoke_path});
+    try stdout.writeStreamingAll(zio(), "\nThis revocation will be broadcast to known peers on next 'meshguard up'.\n");
+}
+
+fn loadPendingOrgRevocations(
+    allocator: std.mem.Allocator,
+    config_dir: []const u8,
+    swim: *lib.discovery.Swim.SwimProtocol,
+    stdout: std.Io.File,
+) !void {
+    const revokes = try lib.identity.Org.loadOrgRevocations(allocator, config_dir);
+    defer allocator.free(revokes);
+
+    for (revokes) |rev| {
+        swim.queueOrgCertRevoke(rev);
+    }
+
+    if (revokes.len > 0) {
+        try writeFormatted(stdout, "  org revocations: {d} pending broadcast(s)\n", .{revokes.len});
+    }
+}
+
 fn cmdRevoke(allocator: std.mem.Allocator, key_or_name: []const u8) !void {
     const config_dir = try Config.ensureConfigDir(allocator);
     defer allocator.free(config_dir);
@@ -992,6 +1079,8 @@ fn cmdUp(allocator: std.mem.Allocator, extra_args: []const []const u8) !void {
         swim.setOrgCert(cert_wire);
         try writeFormatted(stdout, "  org cert: {s} (org member)\n", .{cert.getName()});
     } else |_| {}
+
+    try loadPendingOrgRevocations(allocator, config_dir, &swim, stdout);
 
     // Determine public endpoint: --announce overrides STUN
     if (announce_addr) |addr| {
@@ -4390,6 +4479,26 @@ fn cmdConfigShow(allocator: std.mem.Allocator) !void {
                 try stdout.writeStreamingAll(zio(), "\n");
                 try writeFormatted(stdout, "\x1b[1m─── Vouched Nodes ({d}) ──────────────────────────\x1b[0m\n", .{vouch_count});
                 try writeFormatted(stdout, "  {d} pending vouch(es)\n", .{vouch_count});
+            }
+        } else |_| {}
+    }
+
+    // ─── Org Revocations ───
+    const revoke_dir = std.fs.path.join(allocator, &.{ config_dir, "revoked" }) catch null;
+    defer if (revoke_dir) |rd| allocator.free(rd);
+
+    if (revoke_dir) |rd| {
+        if (std.Io.Dir.openDirAbsolute(zio(), rd, .{ .iterate = true })) |dir| {
+            defer dir.close(zio());
+            var revoke_count: usize = 0;
+            var iter = dir.iterate();
+            while (iter.next(zio()) catch null) |entry| {
+                if (std.mem.endsWith(u8, entry.name, ".revoke")) revoke_count += 1;
+            }
+            if (revoke_count > 0) {
+                try stdout.writeStreamingAll(zio(), "\n");
+                try writeFormatted(stdout, "\x1b[1m─── Org Revocations ({d}) ───────────────────────\x1b[0m\n", .{revoke_count});
+                try writeFormatted(stdout, "  {d} pending revocation(s)\n", .{revoke_count});
             }
         } else |_| {}
     }


### PR DESCRIPTION
## Summary
- Add `meshguard org-revoke <node-key-or-path> [--reason <reason>]` to create signed `OrgCertRevoke` messages from the local org keypair.
- Persist revocations as encoded `0x42` wire messages under `$MESHGUARD_CONFIG_DIR/revoked/*.revoke` and queue them for best-effort SWIM control-plane broadcast on `meshguard up`.
- Retain verified signed revocations in memory for duplicate-suppressed periodic re-broadcast, so peers that learn a revocation can propagate it onward.
- Add org revocation helpers/tests and update CLI/trust/security docs to remove the missing-tooling caveat.

Closes #126

## Validation
- `zig build test --summary all` (110/110)
- `zig build --summary all`
- Windows CLI smoke with isolated `MESHGUARD_CONFIG_DIR`: `keygen`, `org-keygen`, `org-revoke --reason key-compromised`, verified one 138-byte `.revoke` artifact and `config show` pending revocation output
- `zig build -Dtarget=x86_64-linux-gnu -Dno-sodium=true --summary all`
- `zig build -Dtarget=x86_64-macos -Doptimize=ReleaseFast --summary all`
- `zig build -Dtarget=x86_64-freebsd -Doptimize=ReleaseFast --summary all`
- `git diff --check`