### PR TITLE
feat: add certificate v2 WireGuard binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,11 @@ meshguard org-keygen
 
 # Sign a node's identity with the org key
 meshguard org-sign /path/to/node.pub --name node-1
-# → node-1.cert (186 bytes)
+# -> node-1.cert (v1, 186 bytes)
+
+# Or bind the node's WireGuard key in a v2 cert
+meshguard org-sign /path/to/node.pub --name node-1 --wg-pubkey /path/to/node.wg.pub
+# -> node-1.cert (v2, 314 bytes)
 
 # Remote peer: trust the org (one-time)
 meshguard trust <org-pubkey> --org --name eosrio
@@ -149,7 +153,7 @@ For fleets, trust one org public key instead of N individual keys:
 ```
 ~/.config/meshguard/
 ├── identity.key / identity.pub    # Node identity
-├── node.cert                      # Org-signed certificate (186 bytes)
+├── node.cert                      # Org-signed certificate (v1 186 B, v2 314 B)
 ├── authorized_keys/               # Individual peer trust
 │   └── validator-1.pub
 ├── trusted_orgs/                  # Org trust (auto-accept members)
@@ -190,7 +194,7 @@ Trust authorization order:
 - Mesh IPv6 deterministically derived: `Blake3(pubkey) → fd99:6d67::X:Y/64` (ULA, RFC 4193)
 - Dual-stack: both addresses assigned to the TUN interface automatically
 - Authorized keys directory gates mesh membership
-- **Org certificates**: 186-byte Ed25519-signed `NodeCertificate` for fleet trust
+- **Org certificates**: Ed25519-signed `NodeCertificate` for fleet trust; v2 certs also bind the WireGuard public key
 - **Mesh DNS**: deterministic `*.a1b2c3.mesh` domains per org, gossip-propagated aliases
 
 ### Discovery (SWIM)

--- a/docs/concepts/identity-and-trust.md
+++ b/docs/concepts/identity-and-trust.md
@@ -88,7 +88,7 @@ When two nodes discover each other:
 
 ## Org Trust & Certificates
 
-Organizations sign `NodeCertificate` structures (186 bytes) that bind a node's Ed25519 public key to an org identity. See the [Trust Model](/guide/trust-model) guide for full details.
+Organizations sign `NodeCertificate` structures that bind a node's Ed25519 public key to an org identity. v1 certificates are 186 bytes; v2 certificates are 314 bytes and can also bind the node's WireGuard public key. See the [Trust Model](/guide/trust-model) guide for full details.
 
 ## Deterministic Mesh DNS
 

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -41,7 +41,7 @@ meshguard's security model is built on three pillars: **cryptographic identity**
 ### Organization Keys
 
 - **Org admins hold signing keys** — treat like root CA keys
-- **Node certificates** — 186 bytes, stored at `~/.config/meshguard/node.cert`
+- **Node certificates** — v1 186 bytes, v2 314 bytes, stored at `~/.config/meshguard/node.cert`
 - **Revocation** — remove individual trust files immediately with `meshguard revoke`, or sign issuer-scoped org revocations with `meshguard org-revoke`
 
 ## Attack Surface

--- a/docs/concepts/swim-discovery.md
+++ b/docs/concepts/swim-discovery.md
@@ -64,8 +64,9 @@ Gossip entries are **piggybacked** on Ping and Ack messages — no dedicated gos
 
 **Total per entry: 115 bytes.** Ping and Ack also carry an 8-byte incarnation
 after the sequence number so peers can detect restarts. A fully-loaded Ping
-with 8 gossip entries is 970 bytes before the optional 187-byte org certificate
-extension, still under the default 1420-byte MTU.
+with 8 gossip entries is 970 bytes before the optional org certificate
+extension. New v2-sized extensions are 315 bytes including the presence byte,
+still under the default 1420-byte MTU.
 
 ## Handshake Flow
 

--- a/docs/concepts/wire-protocol.md
+++ b/docs/concepts/wire-protocol.md
@@ -83,8 +83,12 @@ org certificate extension.
 The optional org certificate extension is appended to Ping/Ack after gossip as:
 
 ```
-[1B present=1][186B NodeCertificate]
+[1B present=1][314B NodeCertificate max]
 ```
+
+New encoders emit the full 314-byte v2-sized certificate slot. Decoders also
+accept the legacy `[1B present=1][186B NodeCertificate]` extension and zero-fill
+the v2-only fields so v1 certificates continue to work during rollout.
 
 ## HandshakeInitiation (Type 1)
 

--- a/docs/guide/trust-model.md
+++ b/docs/guide/trust-model.md
@@ -63,7 +63,7 @@ For fleet deployments, managing N individual keys becomes impractical. **Org tru
 ```
 ~/.config/meshguard/
 ├── identity.key / identity.pub    # Node identity
-├── node.cert                      # Org-signed certificate (186 bytes)
+├── node.cert                      # Org-signed certificate (v1 186 B, v2 314 B)
 ├── authorized_keys/               # Individual peer trust
 │   └── validator-1.pub
 ├── trusted_orgs/                  # Org trust (auto-accept members)
@@ -75,19 +75,50 @@ For fleet deployments, managing N individual keys becomes impractical. **Org tru
 
 ### NodeCertificate Format
 
-Each certificate is a fixed-size 186-byte binary structure:
+meshguard supports two node-certificate versions during the v2 rollout:
 
-| Field         | Size     | Description                             |
-| ------------- | -------- | --------------------------------------- |
-| `version`     | 1 byte   | Certificate version (currently 1)       |
-| `org_pubkey`  | 32 bytes | Organization Ed25519 public key         |
-| `node_pubkey` | 32 bytes | Node Ed25519 public key                 |
-| `node_name`   | 32 bytes | DNS label, null-padded                  |
-| `issued_at`   | 8 bytes  | Unix timestamp                          |
-| `expires_at`  | 8 bytes  | Unix timestamp (0 = never)              |
-| `flags`       | 1 byte   | Reserved                                |
-| `signature`   | 64 bytes | Ed25519 signature over all prior fields |
-| _padding_     | 8 bytes  | Future expansion                        |
+| Version | Wire size | Description |
+| ------- | --------- | ----------- |
+| v1 | 186 bytes | Org signs node identity, name, issue time, expiry, and flags. WireGuard public keys are still learned from gossip. |
+| v2 | 314 bytes | v1 prefix plus signed WireGuard public key binding, issuer key, and optional delegated-issuer grant signature. |
+
+The shared v1 prefix is:
+
+| Field         | Size     | Description                              |
+| ------------- | -------- | ---------------------------------------- |
+| `version`     | 1 byte   | Certificate version (`1` or `2`)         |
+| `org_pubkey`  | 32 bytes | Organization Ed25519 public key          |
+| `node_pubkey` | 32 bytes | Node Ed25519 public key                  |
+| `node_name`   | 32 bytes | DNS label, null-padded                   |
+| `issued_at`   | 8 bytes  | Unix timestamp                           |
+| `expires_at`  | 8 bytes  | Unix timestamp (0 = never)               |
+| `flags`       | 1 byte   | Delegation flag in v2, reserved in v1    |
+| `signature`   | 64 bytes | Ed25519 signature over versioned payload |
+| _padding_     | 8 bytes  | v1 padding before v2 extension fields    |
+
+v2 appends:
+
+| Field | Size | Description |
+| ----- | ---- | ----------- |
+| `wg_pubkey` | 32 bytes | Signed X25519 WireGuard public key for this node |
+| `issuer_pubkey` | 32 bytes | Zero for normal direct certs, or the delegated issuer key when the delegation flag is set |
+| `delegation_signature` | 64 bytes | Org signature authorizing the delegated issuer; zero for direct org-signed v2 certs |
+
+For direct v2 certs, the org signs the full v2 payload. For delegated v2 certs,
+the issuer signs the node payload and the org signs a one-hop grant to that
+issuer. The issuer can be a human/role key or a partner org key. Revoking the
+issuer with `meshguard org-revoke` invalidates all leaves admitted through that
+issuer for the revoking org.
+
+### v1/v2 Migration Policy
+
+Upgraded meshguard nodes accept legacy v1 certificates and v2 certificates.
+Legacy meshguard nodes accept only v1 certificates. During a mixed-version
+rollout, upgrade binaries first and continue issuing v1 certs until every
+trust-enforcing peer has the v2 parser. Then issue v2 certs, usually with
+`meshguard org-sign --wg-pubkey`, to bind each node identity to its WireGuard
+public key. v1 peers remain supported, but their WireGuard key is still learned
+from gossip instead of the certificate.
 
 ### Mesh DNS
 
@@ -107,8 +138,11 @@ Organizations can also claim **human-readable aliases** (e.g. `*.eosrio.mesh`) v
 # Generate org keypair
 meshguard org-keygen
 
-# Sign a node's key
+# Sign a node's key with a v1 certificate
 meshguard org-sign /path/to/node.pub --name db-1
+
+# Sign a v2 certificate that binds the node's WireGuard public key
+meshguard org-sign /path/to/node.pub --name db-1 --wg-pubkey /path/to/node.wg.pub
 
 # Trust an org (auto-accept all signed nodes)
 meshguard trust <org-pubkey> --org --name eosrio
@@ -159,6 +193,8 @@ When a new peer connects, trust is evaluated in order:
    - Verify Ed25519 signature
    - Check certificate expiry
    - Confirm issuing org is in `trusted_orgs/`
+   - For v2, bind the peer's WireGuard public key from the signed cert
+   - For delegated v2, verify the org-signed issuer grant and issuer signature
 3. **Org vouch check** — has a trusted org vouched for this peer?
 4. **Revocation check** — has the cert/vouch been revoked via gossip?
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -281,7 +281,7 @@ meshguard org-keygen
 Sign a node's public key with the organization key.
 
 ```bash
-meshguard org-sign <node-key-or-path> [--name <label>] [--expires <unix-timestamp>]
+meshguard org-sign <node-key-or-path> [--name <label>] [--expires <unix-timestamp>] [--wg-pubkey <key-or-path>]
 ```
 
 | Argument | Description |
@@ -289,6 +289,11 @@ meshguard org-sign <node-key-or-path> [--name <label>] [--expires <unix-timestam
 | `<node-key-or-path>` | Base64 public key string _or_ path to a `.pub` file |
 | `--name` | Human-readable name for the node |
 | `--expires` | Unix timestamp when the signature expires (default: 0, never expires) |
+| `--wg-pubkey` | Base64 WireGuard public key string _or_ path to a file. When set, emits a v2 certificate that binds node identity to this WireGuard key. |
+
+Without `--wg-pubkey`, `org-sign` emits a legacy v1 certificate for mixed-version
+meshes. With `--wg-pubkey`, it emits a v2 certificate. Upgrade trust-enforcing
+peers before relying on v2-only certificates.
 
 ---
 

--- a/src/discovery/membership.zig
+++ b/src/discovery/membership.zig
@@ -66,6 +66,8 @@ pub const Peer = struct {
     // ── Org trust fields ──
     /// Org public key (if peer authenticated via org cert)
     org_pubkey: ?[32]u8 = null,
+    /// Cert issuer public key when admitted via delegated v2 cert.
+    cert_issuer_pubkey: ?[32]u8 = null,
     /// Node name from certificate (e.g. "node-1")
     org_node_name: [32]u8 = std.mem.zeroes([32]u8),
     /// Certificate expiry (0 = never, null = no cert)

--- a/src/discovery/swim.zig
+++ b/src/discovery/swim.zig
@@ -228,7 +228,7 @@ pub const SwimProtocol = struct {
     vouched_count: usize = 0,
 
     // Node's own org certificate (if any, loaded at init)
-    our_org_cert: ?[186]u8 = null,
+    our_org_cert: ?[messages.ORG_CERT_WIRE_SIZE]u8 = null,
 
     // Control-plane send rate limiting (token bucket). A hard ceiling on
     // SWIM/gossip packets/sec so a pathological inbound rate (e.g. a NAT
@@ -317,6 +317,7 @@ pub const SwimProtocol = struct {
         if (!cert.isValid()) return false;
         if (!self.isOrgAuthorizedPeer(cert.org_pubkey)) return false;
         if (self.orgRevokesNode(cert.org_pubkey, pubkey)) return false;
+        if (cert.isDelegated() and self.orgRevokesNode(cert.org_pubkey, cert.issuer_pubkey)) return false;
         return true;
     }
 
@@ -327,16 +328,50 @@ pub const SwimProtocol = struct {
         if (!self.isOrgAuthorizedPeer(org_pubkey)) return false;
         if (!certExpiryValid(expires_at)) return false;
         if (self.orgRevokesNode(org_pubkey, pubkey)) return false;
+        if (peer.cert_issuer_pubkey) |issuer| {
+            if (self.orgRevokesNode(org_pubkey, issuer)) return false;
+        }
         return true;
+    }
+
+    fn revokedOrgGrantAffectsPeer(rev: messages.OrgCertRevoke, pubkey: [32]u8, peer: Membership.Peer) bool {
+        if (std.mem.eql(u8, &pubkey, &rev.node_pubkey)) return true;
+        const org_pubkey = peer.org_pubkey orelse return false;
+        if (!std.mem.eql(u8, &org_pubkey, &rev.org_pubkey)) return false;
+        if (peer.cert_issuer_pubkey) |issuer| {
+            return std.mem.eql(u8, &issuer, &rev.node_pubkey);
+        }
+        return false;
+    }
+
+    fn bindPeerWgKeyFromCert(self: *SwimProtocol, pubkey: [32]u8, signed_wg: [32]u8) void {
+        const current = self.membership.peers.get(pubkey) orelse return;
+        if (current.wg_pubkey) |existing| {
+            if (std.mem.eql(u8, &existing, &signed_wg)) return;
+            if (self.handler) |h| {
+                h.onPeerDead(h.ctx, pubkey);
+            }
+        }
+        if (self.membership.peers.getPtr(pubkey)) |peer| {
+            peer.wg_pubkey = signed_wg;
+            if (self.handler) |h| {
+                h.onPeerJoin(h.ctx, peer);
+            }
+        }
     }
 
     fn recordPeerCertificate(self: *SwimProtocol, pubkey: [32]u8, cert_wire: [messages.ORG_CERT_WIRE_SIZE]u8) void {
         if (!self.certAuthorizesPeer(pubkey, cert_wire)) return;
         const cert = Org.NodeCertificate.deserialize(&cert_wire);
+        const signed_wg = cert.boundWgPubkey();
         if (self.membership.peers.getPtr(pubkey)) |peer| {
             peer.org_pubkey = cert.org_pubkey;
+            peer.cert_issuer_pubkey = if (cert.isDelegated()) cert.issuer_pubkey else null;
             peer.org_node_name = cert.node_name;
             peer.cert_expires_at = cert.expires_at;
+        }
+        if (signed_wg) |wg| {
+            self.bindPeerWgKeyFromCert(pubkey, wg);
         }
     }
 
@@ -388,7 +423,7 @@ pub const SwimProtocol = struct {
     }
 
     /// Set this node's org certificate.
-    pub fn setOrgCert(self: *SwimProtocol, cert_wire: [186]u8) void {
+    pub fn setOrgCert(self: *SwimProtocol, cert_wire: [messages.ORG_CERT_WIRE_SIZE]u8) void {
         self.our_org_cert = cert_wire;
     }
 
@@ -825,17 +860,25 @@ pub const SwimProtocol = struct {
             self.revoked_count += 1;
             log.warn("node revoked by org (reason={d})", .{rev.reason});
 
-            // If the revoked node is currently authorized only by this org's
-            // cert/vouch, mark it dead. Other orgs or explicit key trust are
-            // independent authorization boundaries.
-            if (self.membership.peers.getPtr(rev.node_pubkey)) |peer| {
-                if ((peer.state == .alive or peer.state == .suspected) and
-                    !self.isAuthorizedPeer(rev.node_pubkey, null))
-                {
-                    self.membership.markDead(rev.node_pubkey);
-                    if (self.handler) |h| {
-                        h.onPeerDead(h.ctx, rev.node_pubkey);
-                    }
+            // If the revoked node, or any leaf cert issued by that node, is
+            // currently authorized only by this org's cert/vouch, mark it dead.
+            // Other orgs or explicit key trust are independent authorization
+            // boundaries.
+            while (true) {
+                var dead_key: ?[32]u8 = null;
+                var iter = self.membership.peers.iterator();
+                while (iter.next()) |entry| {
+                    const peer = entry.value_ptr.*;
+                    if (peer.state != .alive and peer.state != .suspected) continue;
+                    if (!revokedOrgGrantAffectsPeer(rev, entry.key_ptr.*, peer)) continue;
+                    if (self.isAuthorizedPeer(entry.key_ptr.*, null)) continue;
+                    dead_key = entry.key_ptr.*;
+                    break;
+                }
+                const key = dead_key orelse break;
+                self.membership.markDead(key);
+                if (self.handler) |h| {
+                    h.onPeerDead(h.ctx, key);
                 }
             }
         }
@@ -1814,6 +1857,7 @@ fn aliveTestPeer(pk: [32]u8) Membership.Peer {
 
 const JoinCounter = struct {
     count: usize = 0,
+    dead_count: usize = 0,
     last_pubkey: ?[32]u8 = null,
 };
 
@@ -1825,6 +1869,11 @@ fn countPeerJoin(ctx: *anyopaque, peer: *const Membership.Peer) void {
 
 fn ignorePeerDead(_: *anyopaque, _: [32]u8) void {}
 
+fn countPeerDead(ctx: *anyopaque, _: [32]u8) void {
+    const counter: *JoinCounter = @ptrCast(@alignCast(ctx));
+    counter.dead_count += 1;
+}
+
 fn inertTestSocket() Udp.UdpSocket {
     const fd: std.posix.socket_t = if (builtin.os.tag == .windows)
         @as(std.posix.socket_t, @ptrFromInt(std.math.maxInt(usize)))
@@ -1835,6 +1884,20 @@ fn inertTestSocket() Udp.UdpSocket {
 
 fn issueCertWire(org_kp: Org.OrgKeyPair, node_pubkey: [32]u8, name: []const u8) ![messages.ORG_CERT_WIRE_SIZE]u8 {
     var cert = try Org.issueCertificate(org_kp, node_pubkey, name, 0);
+    var cert_wire: [messages.ORG_CERT_WIRE_SIZE]u8 = undefined;
+    cert.serialize(&cert_wire);
+    return cert_wire;
+}
+
+fn issueCertV2Wire(org_kp: Org.OrgKeyPair, node_pubkey: [32]u8, wg_pubkey: [32]u8, name: []const u8) ![messages.ORG_CERT_WIRE_SIZE]u8 {
+    var cert = try Org.issueCertificateV2(org_kp, node_pubkey, wg_pubkey, name, 0);
+    var cert_wire: [messages.ORG_CERT_WIRE_SIZE]u8 = undefined;
+    cert.serialize(&cert_wire);
+    return cert_wire;
+}
+
+fn issueDelegatedCertV2Wire(org_kp: Org.OrgKeyPair, issuer_kp: Org.OrgKeyPair, node_pubkey: [32]u8, wg_pubkey: [32]u8, name: []const u8) ![messages.ORG_CERT_WIRE_SIZE]u8 {
+    var cert = try Org.issueDelegatedCertificateV2(org_kp, issuer_kp, node_pubkey, wg_pubkey, name, 0);
     var cert_wire: [messages.ORG_CERT_WIRE_SIZE]u8 = undefined;
     cert.serialize(&cert_wire);
     return cert_wire;
@@ -2226,6 +2289,153 @@ test "cert-only gossip candidate is probed then graduates on direct cert" {
     try std.testing.expectEqualSlices(u8, &wg_key, &membership.peers.get(node_pubkey).?.wg_pubkey.?);
     try std.testing.expectEqual(@as(usize, 1), joins.count);
     try std.testing.expectEqualSlices(u8, &node_pubkey, &joins.last_pubkey.?);
+}
+
+test "v2 org cert binds WireGuard key on direct cert admission" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+    const socket = inertTestSocket();
+
+    var joins = JoinCounter{};
+    const handler = EventHandler{
+        .ctx = &joins,
+        .onPeerJoin = countPeerJoin,
+        .onPeerDead = countPeerDead,
+    };
+    var swim = SwimProtocol.init(&membership, socket, .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, handler);
+    swim.enableTrust();
+
+    const org_kp = Org.generateOrgKeyPair();
+    const org_pubkey = org_kp.public_key.toBytes();
+    swim.addTrustedOrg(org_pubkey);
+
+    const node_kp = keys.generate();
+    const node_pubkey = node_kp.public_key.toBytes();
+    const signed_wg = [_]u8{0x91} ** 32;
+    const cert_wire = try issueCertV2Wire(org_kp, node_pubkey, signed_wg, "node-v2");
+    const endpoint = messages.Endpoint.initV4(.{ 127, 0, 0, 1 }, 43100);
+
+    var ack_buf: [1500]u8 = undefined;
+    const written = try codec.encodeAck(&ack_buf, .{
+        .sender_pubkey = node_pubkey,
+        .seq = 1,
+        .gossip = &.{},
+        .org_cert = cert_wire,
+        .has_org_cert = true,
+    });
+    swim.handleMessage(ack_buf[0..written], endpoint);
+
+    const recorded = membership.peers.get(node_pubkey).?;
+    try std.testing.expectEqualSlices(u8, &org_pubkey, &recorded.org_pubkey.?);
+    try std.testing.expectEqualSlices(u8, &signed_wg, &recorded.wg_pubkey.?);
+    try std.testing.expectEqual(@as(usize, 1), joins.count);
+    try std.testing.expectEqual(@as(usize, 0), joins.dead_count);
+}
+
+test "v2 org cert overrides preseeded gossip WireGuard key" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+    const socket = inertTestSocket();
+
+    var joins = JoinCounter{};
+    const handler = EventHandler{
+        .ctx = &joins,
+        .onPeerJoin = countPeerJoin,
+        .onPeerDead = countPeerDead,
+    };
+    var swim = SwimProtocol.init(&membership, socket, .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, handler);
+    swim.enableTrust();
+
+    const org_kp = Org.generateOrgKeyPair();
+    swim.addTrustedOrg(org_kp.public_key.toBytes());
+
+    const node_kp = keys.generate();
+    const node_pubkey = node_kp.public_key.toBytes();
+    swim.addAuthorizedKey(node_pubkey);
+
+    const fake_wg = [_]u8{0xF0} ** 32;
+    const signed_wg = [_]u8{0x92} ** 32;
+    const endpoint = messages.Endpoint.initV4(.{ 127, 0, 0, 1 }, 43101);
+
+    swim.applyGossip(.{
+        .subject_pubkey = node_pubkey,
+        .event = .join,
+        .lamport = 1,
+        .endpoint = endpoint,
+        .wg_pubkey = fake_wg,
+    });
+    try std.testing.expectEqualSlices(u8, &fake_wg, &membership.peers.get(node_pubkey).?.wg_pubkey.?);
+    try std.testing.expectEqual(@as(usize, 1), joins.count);
+
+    const cert_wire = try issueCertV2Wire(org_kp, node_pubkey, signed_wg, "node-v2");
+    var ack_buf: [1500]u8 = undefined;
+    const written = try codec.encodeAck(&ack_buf, .{
+        .sender_pubkey = node_pubkey,
+        .seq = 2,
+        .gossip = &.{},
+        .org_cert = cert_wire,
+        .has_org_cert = true,
+    });
+    swim.handleMessage(ack_buf[0..written], endpoint);
+
+    const recorded = membership.peers.get(node_pubkey).?;
+    try std.testing.expectEqualSlices(u8, &signed_wg, &recorded.wg_pubkey.?);
+    try std.testing.expectEqual(@as(usize, 1), joins.dead_count);
+    try std.testing.expectEqual(@as(usize, 2), joins.count);
+}
+
+test "delegated v2 org cert admits and intermediate revocation evicts leaf" {
+    const allocator = std.testing.allocator;
+    var membership = Membership.MembershipTable.init(allocator, 5000);
+    defer membership.deinit();
+    const socket = inertTestSocket();
+
+    var joins = JoinCounter{};
+    const handler = EventHandler{
+        .ctx = &joins,
+        .onPeerJoin = countPeerJoin,
+        .onPeerDead = countPeerDead,
+    };
+    var swim = SwimProtocol.init(&membership, socket, .{}, [_]u8{1} ** 32, [_]u8{2} ** 32, .{ 127, 0, 0, 1 }, 51821, handler);
+    swim.enableTrust();
+
+    const org_kp = Org.generateOrgKeyPair();
+    const issuer_kp = Org.generateOrgKeyPair();
+    const org_pubkey = org_kp.public_key.toBytes();
+    const issuer_pubkey = issuer_kp.public_key.toBytes();
+    swim.addTrustedOrg(org_pubkey);
+
+    const node_kp = keys.generate();
+    const node_pubkey = node_kp.public_key.toBytes();
+    const signed_wg = [_]u8{0x93} ** 32;
+    const cert_wire = try issueDelegatedCertV2Wire(org_kp, issuer_kp, node_pubkey, signed_wg, "delegated");
+    const endpoint = messages.Endpoint.initV4(.{ 127, 0, 0, 1 }, 43102);
+
+    var ack_buf: [1500]u8 = undefined;
+    const written = try codec.encodeAck(&ack_buf, .{
+        .sender_pubkey = node_pubkey,
+        .seq = 3,
+        .gossip = &.{},
+        .org_cert = cert_wire,
+        .has_org_cert = true,
+    });
+    swim.handleMessage(ack_buf[0..written], endpoint);
+
+    var recorded = membership.peers.get(node_pubkey).?;
+    try std.testing.expectEqualSlices(u8, &org_pubkey, &recorded.org_pubkey.?);
+    try std.testing.expectEqualSlices(u8, &issuer_pubkey, &recorded.cert_issuer_pubkey.?);
+    try std.testing.expectEqualSlices(u8, &signed_wg, &recorded.wg_pubkey.?);
+    try std.testing.expect(swim.isAuthorizedPeer(node_pubkey, null));
+
+    const revoke_issuer = try Org.issueOrgRevoke(org_kp, issuer_pubkey, 2, 50);
+    swim.handleOrgRevoke(revoke_issuer);
+
+    recorded = membership.peers.get(node_pubkey).?;
+    try std.testing.expect(!swim.isAuthorizedPeer(node_pubkey, cert_wire));
+    try std.testing.expect(recorded.state == .dead);
+    try std.testing.expectEqual(@as(usize, 1), joins.dead_count);
 }
 
 test "gossiped join still admits an individually authorized subject" {

--- a/src/identity/org.zig
+++ b/src/identity/org.zig
@@ -44,10 +44,16 @@ pub const OrgKeyPair = struct {
 pub const ORG_REVOKE_WIRE_SIZE: usize = 1 + 32 + 32 + 1 + 8 + 64;
 pub const MAX_ORG_REVOKES: usize = 64;
 
+pub const CERT_VERSION_V1: u8 = 1;
+pub const CERT_VERSION_V2: u8 = 2;
+pub const CERT_FLAG_DELEGATED: u8 = 1 << 0;
+pub const V1_CERT_WIRE_SIZE: usize = 186;
+
 /// Fixed-size node certificate signed by an org key.
-/// Total: 186 bytes on the wire.
+/// v1 occupies the first 186 bytes; v2 appends WG key binding and an optional
+/// one-hop delegated issuer grant.
 pub const NodeCertificate = struct {
-    version: u8 = 1,
+    version: u8 = CERT_VERSION_V1,
     org_pubkey: [32]u8,
     node_pubkey: [32]u8,
     node_name: [32]u8, // DNS label, null-padded
@@ -55,15 +61,21 @@ pub const NodeCertificate = struct {
     expires_at: i64, // 0 = never
     flags: u8 = 0, // reserved
     signature: [64]u8 = std.mem.zeroes([64]u8),
+    wg_pubkey: [32]u8 = std.mem.zeroes([32]u8),
+    issuer_pubkey: [32]u8 = std.mem.zeroes([32]u8),
+    delegation_signature: [64]u8 = std.mem.zeroes([64]u8),
 
-    pub const WIRE_SIZE: usize = 186;
+    pub const WIRE_SIZE: usize = messages.ORG_CERT_WIRE_SIZE;
 
     /// The portion of the cert that is signed (everything except signature + padding).
     /// version(1) + org_pubkey(32) + node_pubkey(32) + node_name(32) + issued_at(8) + expires_at(8) + flags(1) = 114 bytes
-    const SIGNED_LEN: usize = 114;
+    const V1_SIGNED_LEN: usize = 114;
+    const V2_SIGNED_LEN: usize = V1_SIGNED_LEN + 32 + 32;
+    const DELEGATION_SIGNED_LEN: usize = 1 + 32 + 32 + 8 + 1;
 
     /// Serialize to a fixed-size wire buffer.
     pub fn serialize(self: *const NodeCertificate, out: *[WIRE_SIZE]u8) void {
+        @memset(out, 0);
         var pos: usize = 0;
         out[pos] = self.version;
         pos += 1;
@@ -81,8 +93,14 @@ pub const NodeCertificate = struct {
         pos += 1;
         @memcpy(out[pos..][0..64], &self.signature);
         pos += 64;
-        // Padding
-        @memset(out[pos..WIRE_SIZE], 0);
+        pos += V1_CERT_WIRE_SIZE - pos;
+        if (self.version >= CERT_VERSION_V2) {
+            @memcpy(out[pos..][0..32], &self.wg_pubkey);
+            pos += 32;
+            @memcpy(out[pos..][0..32], &self.issuer_pubkey);
+            pos += 32;
+            @memcpy(out[pos..][0..64], &self.delegation_signature);
+        }
     }
 
     /// Deserialize from a wire buffer.
@@ -103,6 +121,19 @@ pub const NodeCertificate = struct {
         const flags = data[pos];
         pos += 1;
         const signature = data[pos..][0..64].*;
+        pos += 64;
+        pos += V1_CERT_WIRE_SIZE - pos;
+
+        var wg_pubkey = std.mem.zeroes([32]u8);
+        var issuer_pubkey = std.mem.zeroes([32]u8);
+        var delegation_signature = std.mem.zeroes([64]u8);
+        if (version >= CERT_VERSION_V2) {
+            wg_pubkey = data[pos..][0..32].*;
+            pos += 32;
+            issuer_pubkey = data[pos..][0..32].*;
+            pos += 32;
+            delegation_signature = data[pos..][0..64].*;
+        }
 
         return .{
             .version = version,
@@ -113,12 +144,14 @@ pub const NodeCertificate = struct {
             .expires_at = expires_at,
             .flags = flags,
             .signature = signature,
+            .wg_pubkey = wg_pubkey,
+            .issuer_pubkey = issuer_pubkey,
+            .delegation_signature = delegation_signature,
         };
     }
 
-    /// Extract the signed payload (for signing/verification).
-    fn signedPayload(self: *const NodeCertificate) [SIGNED_LEN]u8 {
-        var buf: [SIGNED_LEN]u8 = undefined;
+    fn signedPayloadV1(self: *const NodeCertificate) [V1_SIGNED_LEN]u8 {
+        var buf: [V1_SIGNED_LEN]u8 = undefined;
         var pos: usize = 0;
         buf[pos] = self.version;
         pos += 1;
@@ -136,11 +169,49 @@ pub const NodeCertificate = struct {
         return buf;
     }
 
+    /// Extract the signed payload (for signing/verification).
+    fn signedPayload(self: *const NodeCertificate) [V2_SIGNED_LEN]u8 {
+        var buf: [V2_SIGNED_LEN]u8 = undefined;
+        const v1 = self.signedPayloadV1();
+        @memcpy(buf[0..V1_SIGNED_LEN], &v1);
+        var pos: usize = V1_SIGNED_LEN;
+        @memcpy(buf[pos..][0..32], &self.wg_pubkey);
+        pos += 32;
+        @memcpy(buf[pos..][0..32], &self.issuer_pubkey);
+        return buf;
+    }
+
+    fn delegationPayload(self: *const NodeCertificate) [DELEGATION_SIGNED_LEN]u8 {
+        var buf: [DELEGATION_SIGNED_LEN]u8 = undefined;
+        var pos: usize = 0;
+        buf[pos] = self.version;
+        pos += 1;
+        @memcpy(buf[pos..][0..32], &self.org_pubkey);
+        pos += 32;
+        @memcpy(buf[pos..][0..32], &self.issuer_pubkey);
+        pos += 32;
+        std.mem.writeInt(i64, buf[pos..][0..8], self.expires_at, .little);
+        pos += 8;
+        buf[pos] = self.flags;
+        return buf;
+    }
+
     /// Check if certificate is expired. Returns true if valid.
     pub fn isValid(self: *const NodeCertificate) bool {
-        if (self.version != 1) return false;
+        if (self.version != CERT_VERSION_V1 and self.version != CERT_VERSION_V2) return false;
+        if (self.version == CERT_VERSION_V2 and std.mem.allEqual(u8, &self.wg_pubkey, 0)) return false;
         if (self.expires_at == 0) return true; // never expires
         return nowUnixSecs() < self.expires_at;
+    }
+
+    pub fn isDelegated(self: *const NodeCertificate) bool {
+        return self.version == CERT_VERSION_V2 and (self.flags & CERT_FLAG_DELEGATED) != 0;
+    }
+
+    pub fn boundWgPubkey(self: *const NodeCertificate) ?[32]u8 {
+        if (self.version != CERT_VERSION_V2) return null;
+        if (std.mem.allEqual(u8, &self.wg_pubkey, 0)) return null;
+        return self.wg_pubkey;
     }
 
     /// Get the node name as a trimmed string (strips null padding).
@@ -234,17 +305,44 @@ pub fn loadOrgKeyPair(allocator: std.mem.Allocator, config_dir: []const u8) !Org
 
 /// Sign a node certificate with the org's private key.
 pub fn signCertificate(cert: *NodeCertificate, org_secret: Ed25519.SecretKey) !void {
-    const payload = cert.signedPayload();
     const kp = try Ed25519.KeyPair.fromSecretKey(org_secret);
+    if (cert.version == CERT_VERSION_V1) {
+        const payload = cert.signedPayloadV1();
+        const sig = try kp.sign(&payload, null);
+        cert.signature = sig.toBytes();
+        return;
+    }
+    const payload = cert.signedPayload();
     const sig = try kp.sign(&payload, null);
     cert.signature = sig.toBytes();
 }
 
 /// Verify a node certificate's signature against the embedded org public key.
 pub fn verifyCertificate(cert: *const NodeCertificate) bool {
+    if (cert.version == CERT_VERSION_V1) {
+        const payload = cert.signedPayloadV1();
+        const org_pk = Ed25519.PublicKey.fromBytes(cert.org_pubkey) catch return false;
+        const sig = Ed25519.Signature.fromBytes(cert.signature);
+        sig.verify(&payload, org_pk) catch return false;
+        return true;
+    }
+    if (cert.version != CERT_VERSION_V2) return false;
+
     const payload = cert.signedPayload();
-    const org_pk = Ed25519.PublicKey.fromBytes(cert.org_pubkey) catch return false;
     const sig = Ed25519.Signature.fromBytes(cert.signature);
+    if (cert.isDelegated()) {
+        if (std.mem.allEqual(u8, &cert.issuer_pubkey, 0)) return false;
+        const issuer_pk = Ed25519.PublicKey.fromBytes(cert.issuer_pubkey) catch return false;
+        sig.verify(&payload, issuer_pk) catch return false;
+
+        const grant_payload = cert.delegationPayload();
+        const org_pk = Ed25519.PublicKey.fromBytes(cert.org_pubkey) catch return false;
+        const grant_sig = Ed25519.Signature.fromBytes(cert.delegation_signature);
+        grant_sig.verify(&grant_payload, org_pk) catch return false;
+        return true;
+    }
+
+    const org_pk = Ed25519.PublicKey.fromBytes(cert.org_pubkey) catch return false;
     sig.verify(&payload, org_pk) catch return false;
     return true;
 }
@@ -269,6 +367,44 @@ pub fn issueCertificate(
     };
 
     try signCertificate(&cert, org_kp.secret_key);
+    return cert;
+}
+
+pub fn issueCertificateV2(
+    org_kp: OrgKeyPair,
+    node_pubkey: [32]u8,
+    wg_pubkey: [32]u8,
+    name: []const u8,
+    expires_at: i64,
+) !NodeCertificate {
+    if (std.mem.allEqual(u8, &wg_pubkey, 0)) return error.InvalidWireGuardKey;
+    var cert = try issueCertificate(org_kp, node_pubkey, name, expires_at);
+    cert.version = CERT_VERSION_V2;
+    cert.wg_pubkey = wg_pubkey;
+    cert.issuer_pubkey = std.mem.zeroes([32]u8);
+    cert.delegation_signature = std.mem.zeroes([64]u8);
+    try signCertificate(&cert, org_kp.secret_key);
+    return cert;
+}
+
+pub fn issueDelegatedCertificateV2(
+    org_kp: OrgKeyPair,
+    issuer_kp: OrgKeyPair,
+    node_pubkey: [32]u8,
+    wg_pubkey: [32]u8,
+    name: []const u8,
+    expires_at: i64,
+) !NodeCertificate {
+    var cert = try issueCertificateV2(org_kp, node_pubkey, wg_pubkey, name, expires_at);
+    cert.flags |= CERT_FLAG_DELEGATED;
+    cert.issuer_pubkey = issuer_kp.public_key.toBytes();
+
+    const grant_payload = cert.delegationPayload();
+    const org_signer = try Ed25519.KeyPair.fromSecretKey(org_kp.secret_key);
+    const grant_sig = try org_signer.sign(&grant_payload, null);
+    cert.delegation_signature = grant_sig.toBytes();
+
+    try signCertificate(&cert, issuer_kp.secret_key);
     return cert;
 }
 
@@ -361,7 +497,10 @@ pub fn loadCertificate(allocator: std.mem.Allocator, path: []const u8) !NodeCert
 
     var wire: [NodeCertificate.WIRE_SIZE]u8 = undefined;
     const n = try readFileBytes(file, &wire);
-    if (n < NodeCertificate.WIRE_SIZE) return error.InvalidCertificate;
+    if (n < V1_CERT_WIRE_SIZE) return error.InvalidCertificate;
+    if (n < NodeCertificate.WIRE_SIZE) {
+        @memset(wire[n..], 0);
+    }
     return NodeCertificate.deserialize(&wire);
 }
 
@@ -484,6 +623,113 @@ test "cert serialize/deserialize round-trip" {
     try std.testing.expectEqual(cert.issued_at, restored.issued_at);
     try std.testing.expectEqual(cert.expires_at, restored.expires_at);
     try std.testing.expectEqualStrings(cert.getName(), restored.getName());
+}
+
+test "v2 cert binds WireGuard key and detects tampering" {
+    const org_kp = generateOrgKeyPair();
+    const node_kp = Ed25519.KeyPair.generate(zio());
+    const wg_pubkey = [_]u8{0x44} ** 32;
+
+    const cert = try issueCertificateV2(
+        org_kp,
+        node_kp.public_key.toBytes(),
+        wg_pubkey,
+        "wg-bound",
+        0,
+    );
+
+    try std.testing.expectEqual(CERT_VERSION_V2, cert.version);
+    try std.testing.expect(verifyCertificate(&cert));
+    try std.testing.expect(cert.isValid());
+    try std.testing.expectEqualSlices(u8, &wg_pubkey, &cert.boundWgPubkey().?);
+    try std.testing.expectError(
+        error.InvalidWireGuardKey,
+        issueCertificateV2(org_kp, node_kp.public_key.toBytes(), std.mem.zeroes([32]u8), "zero-wg", 0),
+    );
+
+    var wire: [NodeCertificate.WIRE_SIZE]u8 = undefined;
+    cert.serialize(&wire);
+    const restored = NodeCertificate.deserialize(&wire);
+    try std.testing.expect(verifyCertificate(&restored));
+    try std.testing.expectEqualSlices(u8, &wg_pubkey, &restored.boundWgPubkey().?);
+
+    var tampered_wg = restored;
+    tampered_wg.wg_pubkey[0] ^= 0x01;
+    try std.testing.expect(!verifyCertificate(&tampered_wg));
+
+    var tampered_issuer = restored;
+    tampered_issuer.issuer_pubkey[0] ^= 0x01;
+    try std.testing.expect(!verifyCertificate(&tampered_issuer));
+}
+
+test "delegated v2 cert verifies issuer and org grant signatures" {
+    const org_kp = generateOrgKeyPair();
+    const issuer_kp = generateOrgKeyPair();
+    const node_kp = Ed25519.KeyPair.generate(zio());
+    const wg_pubkey = [_]u8{0x45} ** 32;
+
+    const cert = try issueDelegatedCertificateV2(
+        org_kp,
+        issuer_kp,
+        node_kp.public_key.toBytes(),
+        wg_pubkey,
+        "delegate",
+        0,
+    );
+
+    try std.testing.expectEqual(CERT_VERSION_V2, cert.version);
+    try std.testing.expect(cert.isDelegated());
+    try std.testing.expect(verifyCertificate(&cert));
+    try std.testing.expect(cert.isValid());
+    try std.testing.expectEqualSlices(u8, &issuer_kp.public_key.toBytes(), &cert.issuer_pubkey);
+    try std.testing.expectEqualSlices(u8, &wg_pubkey, &cert.boundWgPubkey().?);
+
+    var tampered_leaf = cert;
+    tampered_leaf.wg_pubkey[0] ^= 0x01;
+    try std.testing.expect(!verifyCertificate(&tampered_leaf));
+
+    var tampered_grant = cert;
+    tampered_grant.expires_at = 123;
+    try std.testing.expect(!verifyCertificate(&tampered_grant));
+
+    var tampered_issuer = cert;
+    tampered_issuer.issuer_pubkey[0] ^= 0x01;
+    try std.testing.expect(!verifyCertificate(&tampered_issuer));
+}
+
+test "load certificate accepts legacy v1 wire size" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(zio(), ".", allocator);
+    defer allocator.free(tmp_path);
+    const cert_path = try std.fs.path.join(allocator, &.{ tmp_path, "legacy.cert" });
+    defer allocator.free(cert_path);
+
+    const org_kp = generateOrgKeyPair();
+    const node_kp = Ed25519.KeyPair.generate(zio());
+    const cert = try issueCertificate(
+        org_kp,
+        node_kp.public_key.toBytes(),
+        "legacy",
+        0,
+    );
+
+    var wire: [NodeCertificate.WIRE_SIZE]u8 = undefined;
+    cert.serialize(&wire);
+
+    {
+        const file = try std.Io.Dir.createFileAbsolute(zio(), cert_path, .{});
+        defer file.close(zio());
+        try file.writeStreamingAll(zio(), wire[0..V1_CERT_WIRE_SIZE]);
+    }
+
+    const loaded = try loadCertificate(allocator, cert_path);
+    try std.testing.expectEqual(CERT_VERSION_V1, loaded.version);
+    try std.testing.expect(verifyCertificate(&loaded));
+    try std.testing.expect(loaded.isValid());
+    try std.testing.expectEqual(@as(?[32]u8, null), loaded.boundWgPubkey());
 }
 
 test "deterministic org domain" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -32,7 +32,7 @@ const usage =
     \\  revoke      Revoke a peer's public key
     \\  export      Print this node's public key
     \\  org-keygen  Generate a new org keypair
-    \\  org-sign    Sign a node's key with org key (--name <label>)
+    \\  org-sign    Sign a node cert (--name <label>, --wg-pubkey <key>)
     \\  org-vouch   Vouch for an external node (auto-propagates to org members)
     \\  org-revoke  Sign an org certificate revocation
     \\  config show Show local node configuration (works offline)
@@ -506,10 +506,27 @@ fn cmdOrgKeygen(allocator: std.mem.Allocator) !void {
     try writeFormatted(stdout, "  public key: {s}\n", .{pk_b64});
     try writeFormatted(stdout, "  domain:     {s}.mesh\n", .{domain});
     try writeFormatted(stdout, "\nShare the public key with peers who should trust your org.\n", .{});
-    try writeFormatted(stdout, "Sign nodes with: meshguard org-sign <node.pub> --name <label>\n", .{});
+    try writeFormatted(stdout, "Sign nodes with: meshguard org-sign <node.pub> --name <label> [--wg-pubkey <key>]\n", .{});
 }
 
 /// Sign a node's public key with the org private key, producing a NodeCertificate.
+fn loadRaw32KeyArg(key_or_path: []const u8, out: *[32]u8) !void {
+    var raw_buf: [256]u8 = undefined;
+    const key_text = blk: {
+        const file = std.Io.Dir.cwd().openFile(zio(), key_or_path, .{}) catch break :blk key_or_path;
+        defer file.close(zio());
+        var reader = file.reader(zio(), &.{});
+        var total: usize = 0;
+        while (total < raw_buf.len) {
+            const n = reader.interface.readSliceShort(raw_buf[total..]) catch return error.InvalidKey;
+            if (n == 0) break;
+            total += n;
+        }
+        break :blk std.mem.trim(u8, raw_buf[0..total], "\n\r \t");
+    };
+    try std.base64.standard.Decoder.decode(out, key_text);
+}
+
 fn cmdOrgSign(allocator: std.mem.Allocator, node_key_path: []const u8, extra_args: []const []const u8) !void {
     const config_dir = try Config.ensureConfigDir(allocator);
     defer allocator.free(config_dir);
@@ -521,6 +538,7 @@ fn cmdOrgSign(allocator: std.mem.Allocator, node_key_path: []const u8, extra_arg
     // Parse --name and --expires from extra args
     var node_name: []const u8 = "node";
     var expires_at: i64 = 0; // default: never
+    var wg_pubkey: ?[32]u8 = null;
     var j: usize = 0;
     while (j < extra_args.len) : (j += 1) {
         if (std.mem.eql(u8, extra_args[j], "--name")) {
@@ -532,6 +550,23 @@ fn cmdOrgSign(allocator: std.mem.Allocator, node_key_path: []const u8, extra_arg
             if (j + 1 < extra_args.len) {
                 expires_at = std.fmt.parseInt(i64, extra_args[j + 1], 10) catch 0;
                 j += 1;
+            }
+        } else if (std.mem.eql(u8, extra_args[j], "--wg-pubkey")) {
+            if (j + 1 < extra_args.len) {
+                var parsed: [32]u8 = undefined;
+                loadRaw32KeyArg(extra_args[j + 1], &parsed) catch {
+                    try stderr.writeStreamingAll(zio(), "error: invalid WireGuard public key (expected base64 32-byte key or file)\n");
+                    std.process.exit(1);
+                };
+                if (std.mem.allEqual(u8, &parsed, 0)) {
+                    try stderr.writeStreamingAll(zio(), "error: invalid WireGuard public key (all-zero key)\n");
+                    std.process.exit(1);
+                }
+                wg_pubkey = parsed;
+                j += 1;
+            } else {
+                try stderr.writeStreamingAll(zio(), "error: --wg-pubkey requires a value\n");
+                std.process.exit(1);
             }
         }
     }
@@ -551,10 +586,16 @@ fn cmdOrgSign(allocator: std.mem.Allocator, node_key_path: []const u8, extra_arg
     }
 
     // Issue certificate
-    const cert = Org.issueCertificate(org_kp, node_pk_bytes, node_name, expires_at) catch {
-        try stderr.writeStreamingAll(zio(), "error: failed to sign certificate\n");
-        std.process.exit(1);
-    };
+    const cert = if (wg_pubkey) |wg|
+        Org.issueCertificateV2(org_kp, node_pk_bytes, wg, node_name, expires_at) catch {
+            try stderr.writeStreamingAll(zio(), "error: failed to sign certificate\n");
+            std.process.exit(1);
+        }
+    else
+        Org.issueCertificate(org_kp, node_pk_bytes, node_name, expires_at) catch {
+            try stderr.writeStreamingAll(zio(), "error: failed to sign certificate\n");
+            std.process.exit(1);
+        };
 
     // Save certificate
     const cert_filename = try std.fmt.allocPrint(allocator, "{s}.cert", .{node_name});
@@ -567,6 +608,7 @@ fn cmdOrgSign(allocator: std.mem.Allocator, node_key_path: []const u8, extra_arg
 
     const domain = Org.deriveOrgDomain(org_kp.public_key.toBytes());
     try writeFormatted(stdout, "Certificate signed for '{s}'.\n", .{node_name});
+    try writeFormatted(stdout, "  version:     v{d}\n", .{cert.version});
     try writeFormatted(stdout, "  mesh domain: {s}.{s}.mesh\n", .{ node_name, domain });
     try writeFormatted(stdout, "  saved to:    {s}\n", .{cert_path});
     if (expires_at == 0) {
@@ -1074,7 +1116,7 @@ fn cmdUp(allocator: std.mem.Allocator, extra_args: []const []const u8) !void {
     const cert_path = try std.fs.path.join(allocator, &.{ config_dir, "node.cert" });
     defer allocator.free(cert_path);
     if (lib.identity.Org.loadCertificate(allocator, cert_path)) |cert| {
-        var cert_wire: [186]u8 = undefined;
+        var cert_wire: [lib.protocol.Messages.ORG_CERT_WIRE_SIZE]u8 = undefined;
         cert.serialize(&cert_wire);
         swim.setOrgCert(cert_wire);
         try writeFormatted(stdout, "  org cert: {s} (org member)\n", .{cert.getName()});
@@ -4390,6 +4432,7 @@ fn cmdConfigShow(allocator: std.mem.Allocator) !void {
             var org_b64: [44]u8 = undefined;
             const org_pub_b64 = std.base64.standard.Encoder.encode(&org_b64, &cert.org_pubkey);
             try writeFormatted(stdout, "  org public key: {s}\n", .{org_pub_b64});
+            try writeFormatted(stdout, "  cert version:   v{d}\n", .{cert.version});
 
             const node_name = cert.getName();
             try writeFormatted(stdout, "  node name:      {s}\n", .{node_name});
@@ -4404,6 +4447,18 @@ fn cmdConfigShow(allocator: std.mem.Allocator) !void {
                 try stdout.writeStreamingAll(zio(), "  expires:        never\n");
             } else {
                 try writeFormatted(stdout, "  expires:        {d}\n", .{cert.expires_at});
+            }
+
+            if (cert.boundWgPubkey()) |wg_pubkey| {
+                var wg_b64: [44]u8 = undefined;
+                const wg_pub_b64 = std.base64.standard.Encoder.encode(&wg_b64, &wg_pubkey);
+                try writeFormatted(stdout, "  wg public key:  {s}\n", .{wg_pub_b64});
+            }
+
+            if (cert.isDelegated()) {
+                var issuer_b64: [44]u8 = undefined;
+                const issuer_pub_b64 = std.base64.standard.Encoder.encode(&issuer_b64, &cert.issuer_pubkey);
+                try writeFormatted(stdout, "  issuer key:     {s}\n", .{issuer_pub_b64});
             }
 
             if (!cert.isValid()) {

--- a/src/protocol/codec.zig
+++ b/src/protocol/codec.zig
@@ -14,6 +14,7 @@ const messages = @import("messages.zig");
 const ENDPOINT_SIZE = 1 + 1 + 16 + 2;
 const GOSSIP_ENTRY_SIZE = 32 + 1 + 8 + ENDPOINT_SIZE + 1 + 32 + ENDPOINT_SIZE + 1; // 115 bytes
 const ORG_CERT_EXTENSION_SIZE = 1 + messages.ORG_CERT_WIRE_SIZE;
+const ORG_CERT_V1_EXTENSION_SIZE = 1 + 186;
 
 // ─── Encoding ───
 
@@ -468,11 +469,13 @@ fn decodeOrgCertExtension(
     if (pos >= data.len) return;
     if (data[pos] != 1) return;
     // A truncated/malformed trailing extension must not nullify an otherwise-valid
-    // SWIM packet (its liveness + gossip already parsed). Treat a short cert as "no
-    // cert present", mirroring the lenient gossip-entry loop, rather than failing the
-    // whole ping/ack decode.
-    if (pos + ORG_CERT_EXTENSION_SIZE > data.len) return;
-    @memcpy(cert, data[pos + 1 ..][0..messages.ORG_CERT_WIRE_SIZE]);
+    // SWIM packet (its liveness + gossip already parsed). Accept legacy v1
+    // 186-byte certs and zero-fill the v2 extension fields.
+    if (pos + ORG_CERT_V1_EXTENSION_SIZE > data.len) return;
+    @memset(cert, 0);
+    const available = data.len - pos - 1;
+    const copy_len = @min(available, messages.ORG_CERT_WIRE_SIZE);
+    @memcpy(cert[0..copy_len], data[pos + 1 ..][0..copy_len]);
     has_cert.* = true;
 }
 
@@ -691,6 +694,38 @@ test "ack optional org cert extension roundtrip" {
     }
 }
 
+test "ack accepts legacy v1 org cert extension" {
+    const pubkey = [_]u8{0xAA} ** 32;
+    const legacy_cert = [_]u8{0xA1} ** 186;
+    var buf: [1 + 32 + 8 + 8 + 1 + 1 + 186]u8 = undefined;
+    var pos: usize = 0;
+
+    buf[pos] = @intFromEnum(messages.MessageType.ack);
+    pos += 1;
+    @memcpy(buf[pos..][0..32], &pubkey);
+    pos += 32;
+    std.mem.writeInt(u64, buf[pos..][0..8], 99, .little);
+    pos += 8;
+    std.mem.writeInt(u64, buf[pos..][0..8], 0, .little);
+    pos += 8;
+    buf[pos] = 0;
+    pos += 1;
+    buf[pos] = 1;
+    pos += 1;
+    @memcpy(buf[pos..][0..legacy_cert.len], &legacy_cert);
+    pos += legacy_cert.len;
+
+    const decoded = try decode(buf[0..pos]);
+    switch (decoded) {
+        .ack => |a| {
+            try std.testing.expect(a.has_org_cert);
+            try std.testing.expectEqualSlices(u8, &legacy_cert, a.org_cert[0..legacy_cert.len]);
+            try std.testing.expect(std.mem.allEqual(u8, a.org_cert[legacy_cert.len..], 0));
+        },
+        else => return error.InvalidMessageType,
+    }
+}
+
 test "ping with gossip roundtrip" {
     const pubkey = [_]u8{0x01} ** 32;
     const subject = [_]u8{0x02} ** 32;
@@ -874,7 +909,7 @@ test "truncated trailing org-cert flag does not drop the whole packet (C4)" {
     var buf: [600]u8 = undefined;
     const written = try encodePing(&buf, ping);
 
-    // Append a stray cert-present flag (0x01) with no room for the 186-byte cert.
+    // Append a stray cert-present flag (0x01) with no room for a legacy 186-byte cert.
     // Pre-fix this returned error.BufferTooShort and failed the ENTIRE decode,
     // discarding otherwise-valid SWIM liveness + gossip.
     buf[written] = 1;

--- a/src/protocol/messages.zig
+++ b/src/protocol/messages.zig
@@ -5,7 +5,7 @@
 
 const std = @import("std");
 
-pub const ORG_CERT_WIRE_SIZE: usize = 186;
+pub const ORG_CERT_WIRE_SIZE: usize = 314;
 
 /// Message type tag — first byte of every wire message.
 pub const MessageType = enum(u8) {


### PR DESCRIPTION
## Summary

Closes #124.

- add certificate v2 serialization/parsing with an org-signed WireGuard public-key binding
- add one-hop delegated issuer grants so `org -> issuer -> device` admission can be verified, and issuer revocation evicts admitted leaves
- keep v1 certificates valid during rollout by accepting 186-byte legacy cert files/extensions and documenting the mixed v1/v2 migration policy
- update `org-sign --wg-pubkey`, `config show`, and trust/wire-protocol docs for v2 certs

## Validation

- `zig build test --summary all`
- `zig build --summary all`
- `zig build -Dtarget=x86_64-linux-gnu -Dno-sodium=true --summary all`
- `zig build -Dtarget=x86_64-macos -Doptimize=ReleaseFast --summary all`
- `zig build -Dtarget=x86_64-freebsd -Doptimize=ReleaseFast --summary all`
- `git diff --check`
- Windows CLI smoke: generated identity/org keys, signed `org-sign --wg-pubkey`, verified 314-byte v2 cert output, and confirmed `config show` reports v2 plus the bound WireGuard key
